### PR TITLE
Fix handling of missing mapping quality in BamSplitter

### DIFF
--- a/src/spikein.rs
+++ b/src/spikein.rs
@@ -283,7 +283,14 @@ impl BamSplitter {
             let is_qcfail = record.flags().is_qc_fail();
             let is_duplicate = record.flags().is_duplicate();
             let is_secondary = record.flags().is_secondary();
-            let mapq = record.mapping_quality().unwrap().get();
+            let mapq = match record.mapping_quality() {
+                Some(mapq) => mapq.get(),
+                None => {
+                    error!("No mapping quality for record");
+                    self.stats.n_unmapped_reads += 1;
+                    continue;
+                }
+            };
 
             if is_unmapped {
                 self.stats.n_unmapped_reads += 1;


### PR DESCRIPTION
This pull request fixes an issue in the `BamSplitter` where it was not properly handling cases where the mapping quality is missing. Previously, the code would panic when trying to access the mapping quality, but now it gracefully handles the situation by logging an error and skipping the record.