### PR TITLE
refactor(spikein): remove allow_unknown_mapq option from BamSplitter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -493,7 +493,6 @@ fn main() -> Result<()> {
                 input.clone(),
                 output.clone(),
                 exogenous_prefix.clone(),
-                *allow_unknown_mapq,
             ).context("Failed to create BamSplitter")?;
 
             split.split()


### PR DESCRIPTION
refactor(filter): streamline mapping quality filtering logic