### PR TITLE
fix: specify version for ndarray-stats dependency in Cargo.toml

### DIFF
--- a/bamnado/Cargo.toml
+++ b/bamnado/Cargo.toml
@@ -32,7 +32,7 @@ crossbeam = "0.8.4"
 serde_json = "1.0.140"
 sprs = "0.11.4"
 ndarray = "0.17.1"
-ndarray-stats="*"
+ndarray-stats="0.7.0"
 anstyle = "1.0.11"
 futures = "0.3.31"
 tokio = { version = "1.45.1"}


### PR DESCRIPTION
This pull request updates the dependency version for `ndarray-stats` in the `bamnado/Cargo.toml` file to ensure compatibility and stability.

Dependency update:

* Changed the `ndarray-stats` crate version from a wildcard (`*`) to an explicit version (`0.7.0`) in `bamnado/Cargo.toml`, which helps prevent unexpected breaking changes from future releases.