### PR TITLE
feat: improve comparison and aggregation functions 

### DIFF
--- a/bamnado/src/bigwig_compare.rs
+++ b/bamnado/src/bigwig_compare.rs
@@ -1,289 +1,504 @@
-//!  BigWig file comparison utilities.
-//! Aimed at comparing coverage BigWig files, e.g., from different samples or conditions.
-
-use crate::bam_utils::progress_bar;
 use anyhow::Result;
 use bigtools::{DEFAULT_BLOCK_SIZE, DEFAULT_ITEMS_PER_SLOT};
-use indicatif::ProgressIterator;
 use itertools::Itertools;
 use log::info;
-use ndarray::prelude::*;
-use polars::prelude::*;
 use rayon::prelude::*;
-use std::io::Write;
+use std::cmp::{Ordering, min};
+use std::io::{Read, Seek, Write};
 use std::path::Path;
-use tempfile;
 
+/// Pairwise comparison applied to two binned signals.
 #[derive(Debug, Clone, clap::ValueEnum)]
 pub enum Comparison {
+    /// Signal1 - Signal2.
     Subtraction,
+    /// Signal1 / (Signal2 + pseudocount).
     Ratio,
+    /// ln((Signal1 + pseudocount) / (Signal2 + pseudocount)).
     LogRatio,
 }
 
+/// Reduction applied across multiple BigWig inputs.
 #[derive(Debug, Clone, clap::ValueEnum)]
 pub enum AggregationMode {
+    /// Sum of per-bin means from each input.
     Sum,
+    /// Mean of per-bin means from each input.
     Mean,
+    /// Per-bin weighted median across all inputs.
     Median,
+    /// Per-bin maximum across all inputs.
     Max,
+    /// Per-bin minimum across all inputs.
     Min,
 }
 
-/// Read a range from a BigWig file into a provided array chunk.
-///
-/// SAFETY: This function is bounds-safe even if `array_chunk.len()` does not match `(end-start)`.
-fn read_bp_range_into_array_chunk(
-    bw: &Path,
-    chrom: &str,
+/// Minimal interval representation (BigWig yields start/end/value).
+#[derive(Clone, Copy, Debug)]
+struct Iv {
     start: u32,
     end: u32,
-    array_chunk: &mut [f32],
-) -> Result<()> {
-    if array_chunk.is_empty() || end <= start {
-        return Ok(());
+    value: f32,
+}
+
+/// Load all intervals for a chromosome; ensure sorted by coordinate.
+///
+/// BigWig intervals are expected to be non-overlapping; this keeps a defensive sort.
+fn load_intervals_for_chrom<R: Read + Seek>(
+    reader: &mut bigtools::BigWigRead<R>,
+    chrom: &str,
+    chrom_len: u32,
+) -> Result<Vec<Iv>> {
+    let it = reader.get_interval(chrom, 0, chrom_len)?;
+    let mut out = Vec::new();
+    for r in it {
+        let iv = r?;
+        if iv.end <= iv.start {
+            continue;
+        }
+        out.push(Iv {
+            start: iv.start,
+            end: iv.end,
+            value: iv.value,
+        });
+    }
+    out.sort_by(|a, b| a.start.cmp(&b.start).then(a.end.cmp(&b.end)));
+    Ok(out)
+}
+
+/// Compute number of fixed-width bins covering a chromosome.
+fn n_bins(chrom_len: u32, bin_size: u32) -> usize {
+    let bin = bin_size as usize;
+    if bin == 0 {
+        return 0;
+    }
+    (chrom_len as usize).div_ceil(bin)
+}
+
+// -----------------------------
+// Core abstraction 1: binning
+// -----------------------------
+
+/// Accumulates ∫ value(x) dx over fixed-width bins via constant segments,
+/// then converts to mean-per-bin by dividing by bin length.
+struct BinAccumulator {
+    chrom_len: u32,
+    bin_size: u32,
+    sums: Vec<f64>, // per-bin sum of (value * bp)
+}
+
+impl BinAccumulator {
+    fn new(chrom_len: u32, bin_size: u32) -> Self {
+        Self {
+            chrom_len,
+            bin_size,
+            sums: vec![0.0; n_bins(chrom_len, bin_size)],
+        }
     }
 
-    // Hard bound: we can only fill as many bp as array_chunk can hold.
-    let max_fill_end = start.saturating_add(array_chunk.len() as u32);
-    let effective_end = std::cmp::min(end, max_fill_end);
-    if effective_end <= start {
-        return Ok(());
+    /// Integrate a constant segment [start, end) with given value into bins.
+    #[inline]
+    fn add_segment(&mut self, start: u32, end: u32, value: f64) {
+        if self.bin_size == 0 || end <= start {
+            return;
+        }
+
+        let start = start.min(self.chrom_len);
+        let end = end.min(self.chrom_len);
+        if end <= start {
+            return;
+        }
+
+        let mut pos = start;
+        let bin = self.bin_size;
+
+        while pos < end {
+            let bi = pos / bin;
+            let bin_end = ((bi + 1) * bin).min(self.chrom_len);
+            let overlap_end = end.min(bin_end);
+            let overlap_len = (overlap_end - pos) as f64;
+
+            // bi is always in-range because sums length == n_bins(chrom_len, bin)
+            self.sums[bi as usize] += value * overlap_len;
+            pos = overlap_end;
+        }
     }
 
-    let mut bw = bigtools::BigWigRead::open_file(bw)?;
-    let values = bw.get_interval(chrom, start, effective_end)?;
+    /// Convert accumulated sums into mean-per-bin values.
+    fn into_means(self) -> Vec<f32> {
+        let mut out = Vec::with_capacity(self.sums.len());
+        for (i, s) in self.sums.into_iter().enumerate() {
+            let start = (i as u32) * self.bin_size;
+            if start >= self.chrom_len {
+                break;
+            }
+            let end = (start + self.bin_size).min(self.chrom_len);
+            let len = (end - start) as f64;
+            out.push(if len > 0.0 { (s / len) as f32 } else { 0.0 });
+        }
+        out
+    }
+}
 
-    let base_offset = start as usize;
-    let chunk_len = array_chunk.len();
+// ------------------------------------
+// Core abstraction 2: signal stepping
+// ------------------------------------
 
-    for interval_res in values {
-        let interval = interval_res?;
+/// Cursor over a piecewise-constant signal defined by non-overlapping intervals with implicit 0 gaps.
+///
+/// Invariant: at any position `pos`, the signal value is either the active interval's value
+/// or 0. The next possible change occurs at either the active interval end or the next interval start.
+struct StepSignalCursor<'a> {
+    ivs: &'a [Iv],
+    idx: usize,
+}
 
-        // Clip interval to requested region
-        let s = std::cmp::max(interval.start, start) as usize;
-        let e = std::cmp::min(interval.end, effective_end) as usize;
-        if s >= e {
+impl<'a> StepSignalCursor<'a> {
+    fn new(ivs: &'a [Iv]) -> Self {
+        Self { ivs, idx: 0 }
+    }
+
+    /// Return (value_at_pos, next_change_pos) at `pos`.
+    ///
+    /// The next change is either the current interval end or the next interval start.
+    fn fetch(&mut self, pos: u32, chrom_len: u32) -> (f32, u32) {
+        while self.idx < self.ivs.len() && self.ivs[self.idx].end <= pos {
+            self.idx += 1;
+        }
+        if self.idx < self.ivs.len() {
+            let iv = self.ivs[self.idx];
+            if iv.start <= pos && pos < iv.end {
+                (iv.value, iv.end.min(chrom_len))
+            } else {
+                (0.0, iv.start.min(chrom_len))
+            }
+        } else {
+            (0.0, chrom_len)
+        }
+    }
+}
+
+// -----------------------------
+// Binning primitives
+// -----------------------------
+
+/// Bin a single BigWig into mean-per-bin (implicit gaps are zero).
+fn binned_means_single_bw(
+    bw_path: &Path,
+    chrom: &str,
+    chrom_len: u32,
+    bin_size: u32,
+) -> Result<Vec<f32>> {
+    let mut r = bigtools::BigWigRead::open_file(bw_path)?;
+    let ivs = load_intervals_for_chrom(&mut r, chrom, chrom_len)?;
+
+    let mut acc = BinAccumulator::new(chrom_len, bin_size);
+    for iv in ivs {
+        if iv.value == 0.0 {
+            continue;
+        }
+        acc.add_segment(iv.start, iv.end, iv.value as f64);
+    }
+    Ok(acc.into_means())
+}
+
+// -----------------------------
+// Compare (2-signal sweep)
+// -----------------------------
+
+/// Sweep two signals in lockstep and compute per-bin comparison values.
+fn binned_compare_two_bw(
+    bw1: &Path,
+    bw2: &Path,
+    chrom: &str,
+    chrom_len: u32,
+    bin_size: u32,
+    comparison: &Comparison,
+    pseudocount: f64,
+) -> Result<Vec<f32>> {
+    let mut r1 = bigtools::BigWigRead::open_file(bw1)?;
+    let mut r2 = bigtools::BigWigRead::open_file(bw2)?;
+    let a = load_intervals_for_chrom(&mut r1, chrom, chrom_len)?;
+    let b = load_intervals_for_chrom(&mut r2, chrom, chrom_len)?;
+
+    let mut c1 = StepSignalCursor::new(&a);
+    let mut c2 = StepSignalCursor::new(&b);
+    let mut acc = BinAccumulator::new(chrom_len, bin_size);
+
+    let mut pos = 0u32;
+    while pos < chrom_len {
+        let (v1, n1) = c1.fetch(pos, chrom_len);
+        let (v2, n2) = c2.fetch(pos, chrom_len);
+        let mut next = n1.min(n2).min(chrom_len);
+
+        // Defensive: ensure forward progress even with malformed inputs.
+        if next <= pos {
+            next = (pos + 1).min(chrom_len);
+        }
+
+        let out_val = match comparison {
+            Comparison::Subtraction => (v1 as f64) - (v2 as f64),
+            Comparison::Ratio => (v1 as f64) / ((v2 as f64) + pseudocount),
+            Comparison::LogRatio => {
+                (((v1 as f64) + pseudocount) / ((v2 as f64) + pseudocount)).ln()
+            }
+        };
+
+        acc.add_segment(pos, next, out_val);
+        pos = next;
+    }
+
+    Ok(acc.into_means())
+}
+
+// -----------------------------
+// Extrema (N-signal sweep)
+// -----------------------------
+
+/// Sweep N signals and compute a per-bin maximum/minimum.
+fn binned_extrema_multi_bw(
+    bw_paths: &[&Path],
+    chrom: &str,
+    chrom_len: u32,
+    bin_size: u32,
+    want_max: bool,
+    pseudocount: f64, // added to each signal before extrema (matches original intent)
+) -> Result<Vec<f32>> {
+    let mut readers = bw_paths
+        .iter()
+        .map(|p| bigtools::BigWigRead::open_file(*p))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut all_ivs: Vec<Vec<Iv>> = Vec::with_capacity(readers.len());
+    for r in readers.iter_mut() {
+        all_ivs.push(load_intervals_for_chrom(r, chrom, chrom_len)?);
+    }
+
+    let mut cursors: Vec<StepSignalCursor<'_>> = all_ivs
+        .iter()
+        .map(|ivs| StepSignalCursor::new(ivs))
+        .collect();
+    let mut acc = BinAccumulator::new(chrom_len, bin_size);
+
+    let mut pos = 0u32;
+    while pos < chrom_len {
+        let mut next = chrom_len;
+        let mut ext = if want_max {
+            f64::NEG_INFINITY
+        } else {
+            f64::INFINITY
+        };
+
+        for c in cursors.iter_mut() {
+            let (v, n) = c.fetch(pos, chrom_len);
+            next = next.min(n);
+            let vv = (v as f64) + pseudocount;
+            ext = if want_max { ext.max(vv) } else { ext.min(vv) };
+        }
+
+        if next <= pos {
+            next = (pos + 1).min(chrom_len);
+        }
+
+        acc.add_segment(pos, next, ext);
+        pos = next;
+    }
+
+    Ok(acc.into_means())
+}
+
+// -----------------------------
+// Median (weighted, bin-local)
+// -----------------------------
+
+/// Weighted median over a multiset represented as (value, weight=len_in_bp).
+fn weighted_median_from_segments(mut pairs: Vec<(f32, u32)>) -> f32 {
+    if pairs.is_empty() {
+        return 0.0;
+    }
+
+    pairs.sort_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+
+    let total: u64 = pairs.iter().map(|&(_, w)| w as u64).sum();
+    if total == 0 {
+        return 0.0;
+    }
+    let half = total.div_ceil(2); // lower median
+
+    let mut cum: u64 = 0;
+    for (val, w) in pairs {
+        cum += w as u64;
+        if cum >= half {
+            return val;
+        }
+    }
+    0.0
+}
+
+/// Collect (value, weight) segments covering [bin_start, bin_end) for a single BW.
+///
+/// Implicit gaps are represented with `gap_value` and weighted by their bp length.
+fn collect_weighted_values_for_bw_in_bin(
+    ivs: &[Iv],
+    bin_start: u32,
+    bin_end: u32,
+    gap_value: f32,
+) -> Vec<(f32, u32)> {
+    let mut out: Vec<(f32, u32)> = Vec::new();
+    if bin_end <= bin_start {
+        return out;
+    }
+
+    let mut i = ivs.partition_point(|iv| iv.end <= bin_start);
+    let mut pos = bin_start;
+
+    while pos < bin_end {
+        if i >= ivs.len() {
+            out.push((gap_value, bin_end - pos));
+            break;
+        }
+        let iv = ivs[i];
+
+        // gap before next interval
+        if iv.start > pos {
+            let gap_end = min(iv.start, bin_end);
+            if gap_end > pos {
+                out.push((gap_value, gap_end - pos));
+                pos = gap_end;
+                continue;
+            }
+        }
+
+        // skip past intervals that end before pos
+        if iv.end <= pos {
+            i += 1;
             continue;
         }
 
-        for pos in s..e {
-            let idx = pos.saturating_sub(base_offset);
-            if idx < chunk_len {
-                array_chunk[idx] = interval.value;
+        // overlap with current interval
+        if iv.start <= pos && pos < iv.end {
+            let seg_end = min(iv.end, bin_end);
+            if seg_end > pos {
+                out.push((iv.value, seg_end - pos));
+                pos = seg_end;
+                if pos >= iv.end {
+                    i += 1;
+                }
+                continue;
             }
         }
-    }
 
-    Ok(())
-}
-
-/// Fill a bp-resolution ndarray array from a BigWig in bounded parallel chunks.
-fn fill_array_bp(
-    bw_path: &Path,
-    chrom: &str,
-    chrom_len: usize,
-    chunk_size: usize,
-    out: &mut Array1<f32>,
-) -> Result<()> {
-    if out.len() != chrom_len {
-        return Err(anyhow::anyhow!(
-            "Output array length {} does not match chrom_len {}",
-            out.len(),
-            chrom_len
-        ));
-    }
-
-    out.as_slice_mut()
-        .expect("contiguous")
-        .par_chunks_mut(chunk_size)
-        .enumerate()
-        .try_for_each(|(chunk_idx, chunk)| -> Result<()> {
-            let start = chunk_idx * chunk_size;
-            if start >= chrom_len {
-                return Ok(());
-            }
-
-            // Clamp to both chromosome end and actual chunk length.
-            let max_len = chrom_len - start;
-            let eff_len = std::cmp::min(chunk.len(), max_len);
-            if eff_len == 0 {
-                return Ok(());
-            }
-
-            let end = start + eff_len;
-
-            read_bp_range_into_array_chunk(
-                bw_path,
-                chrom,
-                start as u32,
-                end as u32,
-                &mut chunk[..eff_len],
-            )?;
-
-            Ok(())
-        })?;
-
-    Ok(())
-}
-
-/// Fill bp-resolution arrays for many BigWigs in parallel (one array per input file).
-fn fill_arrays_bp<P: AsRef<Path> + Send + Sync>(
-    bw_paths: &[P],
-    chrom: &str,
-    chrom_len: usize,
-    chunk_size: usize,
-) -> Result<Vec<Array1<f32>>> {
-    if bw_paths.is_empty() {
-        return Ok(vec![]);
-    }
-
-    let mut arrays: Vec<Array1<f32>> = (0..bw_paths.len())
-        .map(|_| Array1::<f32>::zeros(chrom_len))
-        .collect();
-
-    arrays
-        .par_iter_mut()
-        .zip(bw_paths.par_iter())
-        .try_for_each(|(arr, p)| fill_array_bp(p.as_ref(), chrom, chrom_len, chunk_size, arr))?;
-
-    Ok(arrays)
-}
-
-/// Turn a single signal into a binned bedGraph-like DataFrame.
-fn binned_df_from_signal(chrom: &str, signal: &Array1<f32>, bin_size: u32) -> Result<DataFrame> {
-    let len = signal.len();
-    if len == 0 {
-        return Ok(DataFrame::empty());
-    }
-
-    let bin = bin_size as usize;
-    if bin == 0 {
-        return Err(anyhow::anyhow!("bin_size must be > 0"));
-    }
-
-    let n_bins = len.div_ceil(bin);
-
-    let mut chroms = Vec::with_capacity(n_bins);
-    let mut starts = Vec::with_capacity(n_bins);
-    let mut ends = Vec::with_capacity(n_bins);
-    let mut values = Vec::with_capacity(n_bins);
-
-    for i in 0..n_bins {
-        let start = i * bin;
-        if start >= len {
+        // defensive progress
+        if iv.start >= bin_end {
             break;
         }
-        let end = std::cmp::min(start + bin, len);
-
-        chroms.push(chrom.to_string());
-        starts.push(start as u32);
-        ends.push(end as u32);
-        values.push(signal.slice(s![start..end]).mean().unwrap_or(0.0));
+        i += 1;
     }
 
-    let mut df = df![
-        "chrom" => chroms,
-        "start" => starts,
-        "end" => ends,
-        "score" => values,
-    ]?;
-    df.sort_in_place(["chrom", "start"], SortMultipleOptions::default())?;
-    Ok(df)
+    out
 }
 
-/// Median aggregation per bin across multiple arrays.
-/// Semantics: flatten all bp values across all inputs within a bin, then take median.
-fn binned_df_median_from_arrays(
+/// Compute per-bin weighted median across multiple BigWigs.
+fn binned_median_multi_bw(
+    bw_paths: &[&Path],
     chrom: &str,
-    arrays: &[Array1<f32>],
+    chrom_len: u32,
     bin_size: u32,
-) -> Result<DataFrame> {
-    if arrays.is_empty() {
-        return Ok(DataFrame::empty());
-    }
-    let len = arrays[0].len();
-    if len == 0 {
-        return Ok(DataFrame::empty());
+    pseudocount: f64,
+) -> Result<Vec<f32>> {
+    let mut readers = bw_paths
+        .iter()
+        .map(|p| bigtools::BigWigRead::open_file(*p))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut all_ivs: Vec<Vec<Iv>> = Vec::with_capacity(readers.len());
+    for r in readers.iter_mut() {
+        let mut ivs = load_intervals_for_chrom(r, chrom, chrom_len)?;
+        if pseudocount != 0.0 {
+            for iv in ivs.iter_mut() {
+                iv.value = (iv.value as f64 + pseudocount) as f32;
+            }
+        }
+        all_ivs.push(ivs);
     }
 
-    let bin = bin_size as usize;
-    if bin == 0 {
+    // NOTE: Original per-bp logic added pseudocount to every base, including gaps.
+    // To match that exactly, use gap_value = pseudocount as f32.
+    let gap_value = pseudocount as f32;
+
+    let nb = n_bins(chrom_len, bin_size);
+    let mut out = Vec::with_capacity(nb);
+
+    for bi in 0..nb {
+        let start = (bi as u32) * bin_size;
+        if start >= chrom_len {
+            break;
+        }
+        let end = min(start + bin_size, chrom_len);
+
+        let mut pairs: Vec<(f32, u32)> = Vec::new();
+        for ivs in &all_ivs {
+            pairs.extend(collect_weighted_values_for_bw_in_bin(
+                ivs, start, end, gap_value,
+            ));
+        }
+        out.push(weighted_median_from_segments(pairs));
+    }
+
+    Ok(out)
+}
+
+// -----------------------------
+// Output writing
+// -----------------------------
+
+/// Write bins in bedGraph format, merging consecutive equal-valued bins.
+fn write_bedgraph_bins<W: Write>(
+    mut w: W,
+    chrom: &str,
+    chrom_len: u32,
+    bin_size: u32,
+    bins: &[f32],
+) -> Result<()> {
+    if bin_size == 0 {
         return Err(anyhow::anyhow!("bin_size must be > 0"));
     }
 
-    // If lengths disagree, be strict (this should never happen).
-    if arrays.iter().any(|a| a.len() != len) {
-        return Err(anyhow::anyhow!(
-            "Input arrays have different lengths for chromosome {}",
-            chrom
-        ));
-    }
-
-    let n_bins = len.div_ceil(bin);
-
-    let mut chroms = Vec::with_capacity(n_bins);
-    let mut starts = Vec::with_capacity(n_bins);
-    let mut ends = Vec::with_capacity(n_bins);
-    let mut values = Vec::with_capacity(n_bins);
-
-    for i in 0..n_bins {
-        let start = i * bin;
-        if start >= len {
+    let mut i = 0usize;
+    while i < bins.len() {
+        let start = (i as u32) * bin_size;
+        if start >= chrom_len {
             break;
         }
-        let end = std::cmp::min(start + bin, len);
+        let mut end = min(start + bin_size, chrom_len);
+        let v = bins[i];
 
-        chroms.push(chrom.to_string());
-        starts.push(start as u32);
-        ends.push(end as u32);
-
-        let mut bin_vals = Vec::with_capacity((end - start) * arrays.len());
-        for arr in arrays {
-            // slice is safe (start/end clamped to len)
-            bin_vals.extend(arr.slice(s![start..end]).iter().copied());
+        // Merge identical consecutive bins to reduce output size.
+        let mut j = i + 1;
+        while j < bins.len() {
+            let s2 = (j as u32) * bin_size;
+            if s2 >= chrom_len {
+                break;
+            }
+            let e2 = min(s2 + bin_size, chrom_len);
+            if bins[j] != v {
+                break;
+            }
+            end = e2;
+            j += 1;
         }
 
-        let med = if bin_vals.is_empty() {
-            0.0
-        } else {
-            bin_vals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-            let mid = bin_vals.len() / 2;
-            if bin_vals.len() % 2 == 0 {
-                (bin_vals[mid - 1] + bin_vals[mid]) / 2.0
-            } else {
-                bin_vals[mid]
-            }
-        };
-        values.push(med);
+        writeln!(w, "{}\t{}\t{}\t{}", chrom, start, end, v)?;
+        i = j;
     }
-
-    let mut df = df![
-        "chrom" => chroms,
-        "start" => starts,
-        "end" => ends,
-        "score" => values,
-    ]?;
-    df.sort_in_place(["chrom", "start"], SortMultipleOptions::default())?;
-    Ok(df)
+    Ok(())
 }
 
-/// Concatenate per-chromosome DataFrames.
-fn concat_dfs(mut dfs: Vec<DataFrame>) -> Result<Option<DataFrame>> {
-    if dfs.is_empty() {
-        return Ok(None);
-    }
-    let mut final_df = dfs.remove(0);
-    for df in dfs.iter() {
-        final_df.vstack_mut(df)?;
-    }
-    Ok(Some(final_df))
-}
-
-/// Write a bedGraph-like DataFrame as a BigWig using bigtools.
-fn write_bedgraph_df_to_bigwig(
-    df: &mut DataFrame,
+/// Write per-chromosome bins to a temporary bedGraph and convert to BigWig.
+fn write_bedgraph_to_bigwig_from_bins(
     chrom_info: &[bigtools::ChromInfo],
+    per_chrom_bins: Vec<(String, Vec<f32>)>,
+    bin_size: u32,
     output_path: &Path,
 ) -> Result<()> {
     // Chromsizes
@@ -295,19 +510,24 @@ fn write_bedgraph_df_to_bigwig(
         }
     }
 
-    // Bedgraph temp
+    // Bedgraph
     info!("Writing temporary bedgraph file");
     let bedgraph_file = tempfile::NamedTempFile::new()?;
-    let bedgraph_path = bedgraph_file.path();
-
-    CsvWriter::new(&bedgraph_file)
-        .include_header(false)
-        .with_separator(b'\t')
-        .finish(df)?;
+    {
+        let mut w = std::io::BufWriter::new(&bedgraph_file);
+        for (chrom, bins) in per_chrom_bins {
+            let clen = chrom_info
+                .iter()
+                .find(|c| c.name == chrom)
+                .map(|c| c.length)
+                .unwrap_or(0);
+            write_bedgraph_bins(&mut w, &chrom, clen, bin_size, &bins)?;
+        }
+    }
 
     // Convert to BigWig
     let args = bigtools::utils::cli::bedgraphtobigwig::BedGraphToBigWigArgs {
-        bedgraph: bedgraph_path.to_string_lossy().to_string(),
+        bedgraph: bedgraph_file.path().to_string_lossy().to_string(),
         chromsizes: chromsizes_file.path().to_string_lossy().to_string(),
         output: output_path.to_string_lossy().to_string(),
         parallel: "auto".to_string(),
@@ -331,14 +551,17 @@ fn write_bedgraph_df_to_bigwig(
     Ok(())
 }
 
-/// Compare two BigWig files and output the result as a BigWig.
+// -----------------------------
+// Public API
+// -----------------------------
+
+/// Compare two BigWigs per-bin and emit a new BigWig.
 pub fn compare_bigwigs<P>(
     bw1_path: &P,
     bw2_path: &Path,
     output_path: &Path,
     comparison: Comparison,
     bin_size: u32,
-    chunksize: Option<usize>,
     pseudocount: Option<f64>,
 ) -> Result<()>
 where
@@ -351,48 +574,63 @@ where
         .sorted_by(|a, b| a.name.cmp(&b.name))
         .collect::<Vec<_>>();
 
-    let chunk_size = chunksize.unwrap_or(1_000_000);
-    let pc = pseudocount.unwrap_or(1e-12) as f32;
+    // Small default avoids division-by-zero in ratio/log-ratio modes.
+    let pc = pseudocount.unwrap_or(1e-12);
 
-    let dfs: Vec<DataFrame> = chrom_info
-        .iter()
-        .progress_with(progress_bar(
-            chrom_info.len() as u64,
-            "Processing chromosomes".to_string(),
-        ))
-        .map(|chr| {
-            let len = chr.length as usize;
-
-            let mut a1 = Array1::<f32>::zeros(len);
-            let mut a2 = Array1::<f32>::zeros(len);
-
-            fill_array_bp(bw1_path.as_ref(), &chr.name, len, chunk_size, &mut a1)?;
-            fill_array_bp(bw2_path, &chr.name, len, chunk_size, &mut a2)?;
-
-            let diff = match comparison {
-                Comparison::Subtraction => &a1 - &a2,
-                Comparison::Ratio => &a1 / (&a2 + pc),
-                Comparison::LogRatio => ((&a1 + pc) / (&a2 + pc)).mapv(|x| x.ln()),
-            };
-
-            binned_df_from_signal(&chr.name, &diff, bin_size)
+    let mut per_chrom_bins = chrom_info
+        .par_iter()
+        .enumerate()
+        .map(|(idx, chr)| {
+            let bins = binned_compare_two_bw(
+                bw1_path.as_ref(),
+                bw2_path,
+                &chr.name,
+                chr.length,
+                bin_size,
+                &comparison,
+                pc,
+            )?;
+            Ok((idx, chr.name.clone(), bins))
         })
         .collect::<Result<Vec<_>>>()?;
+    per_chrom_bins.sort_by_key(|(idx, _, _)| *idx);
+    let per_chrom_bins = per_chrom_bins
+        .into_iter()
+        .map(|(_, name, bins)| (name, bins))
+        .collect::<Vec<_>>();
 
-    let Some(mut final_df) = concat_dfs(dfs)? else {
-        return Ok(());
-    };
-
-    write_bedgraph_df_to_bigwig(&mut final_df, &chrom_info, output_path)
+    write_bedgraph_to_bigwig_from_bins(&chrom_info, per_chrom_bins, bin_size, output_path)
 }
 
-/// Aggregate multiple BigWigs into a single output BigWig.
+/// Streamed Sum/Mean aggregation: avoids Vec<Vec<_>> and avoids allocating a 2D matrix.
+fn binned_sum_or_mean(
+    bw_refs: &[&Path],
+    chrom: &str,
+    chrom_len: u32,
+    bin_size: u32,
+    pseudocount: f64,
+    want_mean: bool,
+) -> Result<Vec<f32>> {
+    let nb = n_bins(chrom_len, bin_size);
+    let mut acc = vec![0f64; nb];
+
+    for p in bw_refs {
+        let bins = binned_means_single_bw(p, chrom, chrom_len, bin_size)?;
+        for (i, &x) in bins.iter().enumerate() {
+            acc[i] += (x as f64) + pseudocount;
+        }
+    }
+
+    let denom = if want_mean { bw_refs.len() as f64 } else { 1.0 };
+    Ok(acc.into_iter().map(|s| (s / denom) as f32).collect())
+}
+
+/// Aggregate multiple BigWigs per-bin and emit a new BigWig.
 pub fn aggregate_bigwigs<P>(
     bw_paths: &[P],
     output_path: &Path,
     aggregation_mode: AggregationMode,
     bin_size: u32,
-    chunksize: Option<usize>,
     pseudocount: Option<f64>,
 ) -> Result<()>
 where
@@ -409,64 +647,41 @@ where
         .sorted_by(|a, b| a.name.cmp(&b.name))
         .collect::<Vec<_>>();
 
-    let chunk_size = chunksize.unwrap_or(1_000_000);
-    let pc = pseudocount.unwrap_or(0.0) as f32;
+    let pc = pseudocount.unwrap_or(0.0);
+    let bw_refs: Vec<&Path> = bw_paths.iter().map(|p| p.as_ref()).collect();
 
-    let dfs: Vec<DataFrame> = chrom_info
-        .iter()
-        .progress_with(progress_bar(
-            chrom_info.len() as u64,
-            "Processing chromosomes".to_string(),
-        ))
-        .map(|chr| {
-            let len = chr.length as usize;
-
-            let mut arrays = fill_arrays_bp(bw_paths, &chr.name, len, chunk_size)?;
-
-            // Add pseudocount to all arrays (in-place)
-            arrays.iter_mut().for_each(|a| *a = &*a + pc);
-
-            match aggregation_mode {
-                AggregationMode::Median => {
-                    binned_df_median_from_arrays(&chr.name, &arrays, bin_size)
-                }
-
+    let mut per_chrom_bins = chrom_info
+        .par_iter()
+        .enumerate()
+        .map(|(idx, chr)| {
+            let clen = chr.length;
+            let bins = match aggregation_mode {
                 AggregationMode::Sum => {
-                    let agg = arrays
-                        .iter()
-                        .skip(1)
-                        .fold(arrays[0].clone(), |acc, a| &acc + a);
-                    binned_df_from_signal(&chr.name, &agg, bin_size)
+                    binned_sum_or_mean(&bw_refs, &chr.name, clen, bin_size, pc, false)?
                 }
                 AggregationMode::Mean => {
-                    let sum = arrays
-                        .iter()
-                        .skip(1)
-                        .fold(arrays[0].clone(), |acc, a| &acc + a);
-                    let agg = sum / arrays.len() as f32;
-                    binned_df_from_signal(&chr.name, &agg, bin_size)
+                    binned_sum_or_mean(&bw_refs, &chr.name, clen, bin_size, pc, true)?
                 }
                 AggregationMode::Max => {
-                    let agg = arrays.iter().skip(1).fold(arrays[0].clone(), |acc, a| {
-                        acc.iter().zip(a.iter()).map(|(x, y)| x.max(*y)).collect()
-                    });
-                    binned_df_from_signal(&chr.name, &agg, bin_size)
+                    binned_extrema_multi_bw(&bw_refs, &chr.name, clen, bin_size, true, pc)?
                 }
                 AggregationMode::Min => {
-                    let agg = arrays.iter().skip(1).fold(arrays[0].clone(), |acc, a| {
-                        acc.iter().zip(a.iter()).map(|(x, y)| x.min(*y)).collect()
-                    });
-                    binned_df_from_signal(&chr.name, &agg, bin_size)
+                    binned_extrema_multi_bw(&bw_refs, &chr.name, clen, bin_size, false, pc)?
                 }
-            }
+                AggregationMode::Median => {
+                    binned_median_multi_bw(&bw_refs, &chr.name, clen, bin_size, pc)?
+                }
+            };
+            Ok((idx, chr.name.clone(), bins))
         })
         .collect::<Result<Vec<_>>>()?;
+    per_chrom_bins.sort_by_key(|(idx, _, _)| *idx);
+    let per_chrom_bins = per_chrom_bins
+        .into_iter()
+        .map(|(_, name, bins)| (name, bins))
+        .collect::<Vec<_>>();
 
-    let Some(mut final_df) = concat_dfs(dfs)? else {
-        return Ok(());
-    };
-
-    write_bedgraph_df_to_bigwig(&mut final_df, &chrom_info, output_path)
+    write_bedgraph_to_bigwig_from_bins(&chrom_info, per_chrom_bins, bin_size, output_path)
 }
 
 #[cfg(test)]
@@ -524,6 +739,47 @@ mod tests {
     }
 
     #[test]
+    fn test_write_bedgraph_bins_collapses_equal_signals() -> Result<()> {
+        let tmp = tempfile::NamedTempFile::new()?;
+        {
+            let mut w = std::io::BufWriter::new(&tmp);
+            let bins = vec![1.0f32, 1.0, 2.0, 2.0, 1.0];
+            write_bedgraph_bins(&mut w, "chr1", 500, 100, &bins)?;
+        }
+        let contents = std::fs::read_to_string(tmp.path())?;
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 3);
+
+        let parse_line = |s: &str| -> Result<(String, u32, u32, f32)> {
+            let parts: Vec<&str> = s.split_whitespace().collect();
+            Ok((
+                parts[0].to_string(),
+                parts[1].parse()?,
+                parts[2].parse()?,
+                parts[3].parse()?,
+            ))
+        };
+
+        let l0 = parse_line(lines[0])?;
+        assert_eq!(l0.0, "chr1");
+        assert_eq!(l0.1, 0);
+        assert_eq!(l0.2, 200);
+        assert!((l0.3 - 1.0).abs() < 1e-6);
+
+        let l1 = parse_line(lines[1])?;
+        assert_eq!(l1.1, 200);
+        assert_eq!(l1.2, 400);
+        assert!((l1.3 - 2.0).abs() < 1e-6);
+
+        let l2 = parse_line(lines[2])?;
+        assert_eq!(l2.1, 400);
+        assert_eq!(l2.2, 500);
+        assert!((l2.3 - 1.0).abs() < 1e-6);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_compare_bigwigs_subtraction() -> Result<()> {
         let dir = tempfile::tempdir()?;
         let bw1_path = dir.path().join("test1.bw");
@@ -551,7 +807,6 @@ mod tests {
             &out_path,
             Comparison::Subtraction,
             10,
-            None,
             None,
         )?;
 
@@ -596,15 +851,7 @@ mod tests {
         let values2 = vec![("chr1".to_string(), 0, 100, 5.0)];
         create_dummy_bigwig(&bw2_path, chrom_map.clone(), values2)?;
 
-        compare_bigwigs(
-            &bw1_path,
-            &bw2_path,
-            &out_path,
-            Comparison::Ratio,
-            10,
-            None,
-            None,
-        )?;
+        compare_bigwigs(&bw1_path, &bw2_path, &out_path, Comparison::Ratio, 10, None)?;
 
         assert!(out_path.exists());
 
@@ -650,7 +897,6 @@ mod tests {
             Comparison::Subtraction,
             10,
             None,
-            None,
         )?;
         compare_bigwigs(
             &bw1_path,
@@ -659,7 +905,6 @@ mod tests {
             Comparison::Ratio,
             10,
             None,
-            None,
         )?;
         compare_bigwigs(
             &bw1_path,
@@ -667,7 +912,6 @@ mod tests {
             &out_logratio,
             Comparison::LogRatio,
             10,
-            None,
             None,
         )?;
 
@@ -734,7 +978,6 @@ mod tests {
             &out_ratio,
             Comparison::Ratio,
             10,
-            None,
             Some(1e-3),
         )?;
         compare_bigwigs(
@@ -743,7 +986,6 @@ mod tests {
             &out_logratio,
             Comparison::LogRatio,
             10,
-            None,
             Some(1e-3),
         )?;
 

--- a/bamnado/src/main.rs
+++ b/bamnado/src/main.rs
@@ -221,10 +221,6 @@ enum Commands {
         #[arg(short = 's', long, default_value = "50")]
         bin_size: u32,
 
-        /// Chunk size for processing
-        #[arg(long)]
-        chunk_size: Option<usize>,
-
         /// Pseudocount value to add to all values
         #[arg(long)]
         pseudocount: Option<f64>,
@@ -694,7 +690,7 @@ fn main() -> Result<()> {
             output,
             comparison,
             bin_size,
-            chunk_size,
+            chunk_size: _,
             pseudocount,
         } => {
             bamnado::bigwig_compare::compare_bigwigs(
@@ -703,7 +699,6 @@ fn main() -> Result<()> {
                 output,
                 comparison.clone(),
                 *bin_size,
-                *chunk_size,
                 *pseudocount,
             )
             .context("Failed to compare BigWig files")?;
@@ -719,7 +714,6 @@ fn main() -> Result<()> {
             output,
             method,
             bin_size,
-            chunk_size,
             pseudocount,
         } => {
             if bigwigs.is_empty() {
@@ -731,7 +725,6 @@ fn main() -> Result<()> {
                 output,
                 method.clone(),
                 *bin_size,
-                *chunk_size,
                 *pseudocount,
             )
             .context("Failed to aggregate BigWig files")?;


### PR DESCRIPTION
This pull request removes the unused `chunk_size` argument from the `compare` and `aggregate` commands in `bamnado/src/main.rs`, simplifying the command-line interface and related function calls.

Command-line interface cleanup:

* Removed the `chunk_size` argument from the `compare` and `aggregate` commands in the `Commands` enum, streamlining user input options.

Function call simplification:

* Updated the main function to ignore `chunk_size` for the `compare` and `aggregate` commands, and removed its usage from the function calls to `bamnado::bigwig_compare::compare_bigwigs` and `bamnado::bigwig_compare::aggregate_bigwigs`. [[1]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cL697-R693) [[2]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cL706) [[3]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cL722) [[4]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cL734)