### PR TITLE
Add BAMNADO program group to BAM headers and enhance BigWig writing

### DIFF
--- a/bamnado-python/src/lib.rs
+++ b/bamnado-python/src/lib.rs
@@ -281,6 +281,7 @@ mod _bamnado {
             ignore_scaffold_chromosomes,
             None,
             None,
+            None,
         );
 
         let signal = bam_pileup

--- a/bamnado/src/bam_modifier.rs
+++ b/bamnado/src/bam_modifier.rs
@@ -6,7 +6,7 @@
 //! It is useful for preprocessing BAM files before downstream analysis, ensuring that
 //! reads are correctly positioned and filtered.
 
-use crate::bam_utils::get_bam_header;
+use crate::bam_utils::{add_bamnado_program_group, get_bam_header};
 
 use crate::read_filter::BamReadFilter;
 use anyhow::Context;
@@ -63,6 +63,7 @@ impl BamModifier {
             Ok(header) => header,
             Err(_e) => get_bam_header(&filepath)?,
         };
+        let output_header = add_bamnado_program_group(&header)?;
 
         let index_path = self.filepath.with_extension("bam.bai");
         let index_file = File::open(&index_path).await?;
@@ -71,7 +72,7 @@ impl BamModifier {
 
         // Make writer
         let mut writer = AsyncWriter::new(File::create(outfile).await?);
-        writer.write_header(&header).await?;
+        writer.write_header(&output_header).await?;
 
         // Get the chromosome sizes
         let chromsizes = header
@@ -214,14 +215,14 @@ impl BamModifier {
                                 }
                             }
 
-                            writer.write_alignment_record(&header, &aln).await?;
+                            writer.write_alignment_record(&output_header, &aln).await?;
                         }
                     } else {
                         warn!("Skipping record with invalid alignment start: {record:?}");
                     }
                 } else {
                     // Write the record without TN5 shift
-                    writer.write_record(&header, &record).await?;
+                    writer.write_record(&output_header, &record).await?;
                 }
             }
         }

--- a/bamnado/src/bam_splitter.rs
+++ b/bamnado/src/bam_splitter.rs
@@ -9,8 +9,7 @@
 //! *   Filtering reads during the splitting process.
 //! *   Asynchronous I/O for high performance.
 
-use crate::bam_utils::BamStats;
-use crate::bam_utils::get_bam_header;
+use crate::bam_utils::{BamStats, add_bamnado_program_group, get_bam_header};
 use crate::read_filter::BamReadFilter;
 use anyhow::Result;
 use crossbeam::channel::unbounded;
@@ -63,6 +62,7 @@ impl BamFilterer {
             Ok(header) => header,
             Err(_e) => get_bam_header(&filepath)?,
         };
+        let output_header = add_bamnado_program_group(&header)?;
 
         let index_path = self.filepath.with_extension("bam.bai");
         let index_file = File::open(&index_path).await?;
@@ -71,7 +71,7 @@ impl BamFilterer {
 
         // Make writer
         let mut writer = AsyncWriter::new(File::create(outfile).await?);
-        writer.write_header(&header).await?;
+        writer.write_header(&output_header).await?;
 
         // Get the chromosome sizes
         let chromsizes = header
@@ -99,7 +99,7 @@ impl BamFilterer {
             while query.read_record(&mut record).await? != 0 {
                 let is_valid = self.filter.is_valid(&record, Some(&header))?;
                 if is_valid {
-                    writer.write_record(&header, &record).await?;
+                    writer.write_record(&output_header, &record).await?;
                 }
             }
         }
@@ -138,15 +138,20 @@ impl BamFilterer {
                 .build_from_path(&filepath)
                 .expect("Error reading file");
             let header = get_bam_header(&filepath).expect("Error reading header");
+            let output_header =
+                add_bamnado_program_group(&header).expect("Error creating output BAM header");
 
             let mut writer = bam::io::writer::Builder {}
                 .build_from_path(outfile)
                 .expect("Error writing to file");
+            writer
+                .write_header(&output_header)
+                .expect("Error writing BAM header");
 
             for chunk in rx.iter() {
                 for record in chunk {
                     writer
-                        .write_record(&header, &record)
+                        .write_record(&output_header, &record)
                         .expect("Error writing record");
                 }
             }
@@ -179,5 +184,55 @@ impl BamFilterer {
 
         handle.join().expect("Error joining threads");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noodles::sam::header::record::value::map::program::tag as pg_tag;
+    use tempfile::TempDir;
+
+    fn test_bam() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("Failed to get workspace root")
+            .join("test/data/test.bam")
+    }
+
+    #[test]
+    fn test_split_writes_bamnado_program_group_to_header() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let output_bam = temp_dir.path().join("filtered.bam");
+
+        let filterer = BamFilterer::new(test_bam(), output_bam.clone(), BamReadFilter::default());
+        filterer.split().expect("Failed to split BAM");
+
+        let mut reader = bam::io::reader::Builder
+            .build_from_path(&output_bam)
+            .expect("Failed to open output BAM");
+        let header = reader
+            .read_header()
+            .expect("Failed to read output BAM header");
+        let program = header
+            .programs()
+            .as_ref()
+            .get(&b"bamnado"[..])
+            .expect("Missing bamnado @PG record");
+
+        assert_eq!(
+            program
+                .other_fields()
+                .get(&pg_tag::NAME)
+                .map(|v| v.as_ref()),
+            Some(&b"bamnado"[..])
+        );
+        assert_eq!(
+            program
+                .other_fields()
+                .get(&pg_tag::VERSION)
+                .map(|v| v.as_ref()),
+            Some(env!("CARGO_PKG_VERSION").as_bytes())
+        );
     }
 }

--- a/bamnado/src/bam_utils.rs
+++ b/bamnado/src/bam_utils.rs
@@ -15,6 +15,7 @@ use log::debug;
 
 use bio_types::strand::Strand as BioStrand;
 use noodles::core::{Position, Region};
+use noodles::sam::header::record::value::{Map, map::Program, map::program::tag as pg_tag};
 use noodles::{bam, bed, sam};
 use polars::prelude::*;
 use rust_lapper::Interval;
@@ -27,6 +28,9 @@ use std::str::FromStr;
 pub const CB: [u8; 2] = [b'C', b'B'];
 /// Type alias for an interval with a `u32` value.
 pub type Iv = Interval<usize, u32>;
+const BAMNADO_PROGRAM_ID: &str = "bamnado";
+const BAMNADO_PROGRAM_NAME: &str = "bamnado";
+const BAMNADO_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Represents the strand of a genomic feature.
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
@@ -490,32 +494,6 @@ impl BamStats {
         Ok(chromsizes)
     }
 
-    /// Writes chromosome sizes to a TSV file.
-    pub fn write_chromsizes(&self, outfile: PathBuf) -> Result<()> {
-        let chrom_sizes = self.chromsizes_ref_name()?;
-        // Convert the chromosome sizes to a DataFrame
-        let mut df = DataFrame::new(vec![
-            Column::new(
-                "chrom".into(),
-                chrom_sizes.keys().cloned().collect::<Vec<String>>(),
-            ),
-            Column::new(
-                "length".into(),
-                chrom_sizes.values().cloned().collect::<Vec<u64>>(),
-            ),
-        ])?;
-
-        // Sort the DataFrame by chromosome name
-        df.sort_in_place(["chrom"], SortMultipleOptions::default())?;
-
-        let mut file = std::fs::File::create(outfile)?;
-        CsvWriter::new(&mut file)
-            .include_header(false)
-            .with_separator(b'\t')
-            .finish(&mut df)?;
-        Ok(())
-    }
-
     /// Returns the number of mapped reads.
     pub fn n_mapped(&self) -> u64 {
         self.n_mapped
@@ -529,6 +507,11 @@ impl BamStats {
     /// Returns the total number of reads.
     pub fn n_total_reads(&self) -> u64 {
         self.n_reads
+    }
+
+    /// Returns a reference to the BAM header.
+    pub fn header(&self) -> &sam::Header {
+        &self.header
     }
 
     /// Checks whether the BAM file contains paired-end reads by inspecting the first few records.
@@ -727,15 +710,79 @@ where
     Ok(header)
 }
 
+/// Returns a BAM header annotated with a `@PG` record for the current bamnado run.
+pub fn add_bamnado_program_group(header: &sam::Header) -> Result<sam::Header> {
+    let mut output_header = header.clone();
+    let mut program = Map::<Program>::default();
+
+    program
+        .other_fields_mut()
+        .insert(pg_tag::NAME, BAMNADO_PROGRAM_NAME.into());
+    program
+        .other_fields_mut()
+        .insert(pg_tag::VERSION, BAMNADO_VERSION.into());
+
+    if let Some(command_line) = bamnado_command_line() {
+        program
+            .other_fields_mut()
+            .insert(pg_tag::COMMAND_LINE, command_line.into());
+    }
+
+    output_header
+        .programs_mut()
+        .add(BAMNADO_PROGRAM_ID, program)
+        .context("Failed to append bamnado @PG header record")?;
+
+    Ok(output_header)
+}
+
+fn bamnado_command_line() -> Option<String> {
+    let args = std::env::args_os()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+
+    (!args.is_empty()).then(|| args.join(" "))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use noodles::sam::header::record::value::map::program::tag as pg_tag;
 
     fn test_bam() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .expect("Failed to get workspace root")
             .join("test/data/test.bam")
+    }
+
+    #[test]
+    fn test_add_bamnado_program_group_appends_pg_record() {
+        let header = sam::Header::default();
+        let output_header =
+            add_bamnado_program_group(&header).expect("Failed to add bamnado program group");
+
+        let program = output_header
+            .programs()
+            .as_ref()
+            .get(&b"bamnado"[..])
+            .expect("Missing bamnado @PG record");
+
+        assert_eq!(
+            program
+                .other_fields()
+                .get(&pg_tag::NAME)
+                .map(|v| v.as_ref()),
+            Some(&b"bamnado"[..])
+        );
+        assert_eq!(
+            program
+                .other_fields()
+                .get(&pg_tag::VERSION)
+                .map(|v| v.as_ref()),
+            Some(env!("CARGO_PKG_VERSION").as_bytes())
+        );
+        assert!(program.other_fields().contains_key(&pg_tag::COMMAND_LINE));
     }
 
     #[test]

--- a/bamnado/src/coverage_analysis.rs
+++ b/bamnado/src/coverage_analysis.rs
@@ -9,6 +9,7 @@
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use crate::bam_utils::{BamStats, Iv, get_bam_header, progress_bar};
 use crate::genomic_intervals::{IntervalMaker, Shift, Truncate};
@@ -18,16 +19,24 @@ use ahash::HashMap;
 use anyhow::{Context, Result};
 #[cfg(test)]
 use bigtools::BigWigRead;
-use bigtools::{DEFAULT_BLOCK_SIZE, DEFAULT_ITEMS_PER_SLOT};
+use bigtools::beddata::BedParserStreamingIterator;
+use bigtools::{BigWigWrite, Value};
 use indicatif::ParallelProgressIterator;
-use log::{debug, error, info};
+use log::{debug, info};
 use noodles::bam;
 use polars::lazy::dsl::col;
 use polars::prelude::*;
 use rayon::prelude::*;
 use regex::Regex;
 use rust_lapper::Lapper;
-use tempfile;
+
+/// Check if a chromosome name is a scaffold.
+fn is_scaffold(name: &str) -> bool {
+    static SCAFFOLD_REGEX: OnceLock<Regex> = OnceLock::new();
+    SCAFFOLD_REGEX
+        .get_or_init(|| Regex::new("(chrUn.*|.*alt|.*random)").unwrap())
+        .is_match(name)
+}
 
 /// Write a DataFrame as a bedGraph file (tab-separated, no header).
 fn write_bedgraph(
@@ -38,13 +47,12 @@ fn write_bedgraph(
     // If ignore_scaffold_chromosomes is true, filter out scaffold chromosomes
     let mut df = match ignore_scaffold_chromosomes {
         true => {
-            let pattern = Regex::new("(chrUn.*|.*alt|.*random)").unwrap();
             let mask = df
                 .column("chrom")?
                 .str()?
                 .iter()
                 .flatten()
-                .map(|s| !pattern.is_match(s))
+                .map(|s| !is_scaffold(s))
                 .collect::<BooleanChunked>();
             df.filter(&mask)?
         }
@@ -141,6 +149,8 @@ pub struct BamPileup {
     shift: Option<Shift>,
     // Optional truncation to apply to the pileup intervals.
     truncate: Option<Truncate>,
+    // Number of threads for tokio runtime in BigWig writer.
+    nthreads: u32,
 }
 
 impl Display for BamPileup {
@@ -224,6 +234,7 @@ impl BamPileup {
         ignore_scaffold_chromosomes: bool,
         shift: Option<Shift>,
         truncate: Option<Truncate>,
+        nthreads: Option<u32>,
     ) -> Self {
         Self {
             file_path,
@@ -236,6 +247,7 @@ impl BamPileup {
             ignore_scaffold_chromosomes,
             shift,
             truncate,
+            nthreads: nthreads.unwrap_or(6),
         }
     }
 
@@ -596,59 +608,127 @@ impl BamPileup {
 
     /// Write the normalized pileup as a BigWig file.
     ///
-    /// This function writes a temporary bedGraph file and converts it to BigWig.
+    /// Streams pileup intervals directly to BigWigWrite in BAM-header chromosome order.
+    /// Each chromosome's intervals are sorted by start position.
     ///
     /// # Arguments
     ///
     /// * `outfile` - The path to the output BigWig file.
     pub fn to_bigwig(&self, outfile: PathBuf) -> Result<()> {
         let bam_stats = BamStats::new(self.file_path.clone())?;
-        let chromsizes_file = tempfile::NamedTempFile::new()?;
-        let chromsizes_path = chromsizes_file.path();
-        bam_stats.write_chromsizes(chromsizes_path.to_path_buf())?;
+        let header = bam_stats.header();
 
-        let bedgraph_file = tempfile::NamedTempFile::new()?;
-        let bedgraph_path = bedgraph_file.path();
-        self.to_bedgraph(bedgraph_path.to_path_buf())?;
-
-        let args = bigtools::utils::cli::bedgraphtobigwig::BedGraphToBigWigArgs {
-            bedgraph: bedgraph_path.to_path_buf().to_string_lossy().to_string(),
-            chromsizes: chromsizes_path.to_path_buf().to_string_lossy().to_string(),
-            output: outfile.to_string_lossy().to_string(),
-            parallel: "auto".to_string(),
-            single_pass: true,
-            write_args: bigtools::utils::cli::BBIWriteArgs {
-                nthreads: 6,
-                nzooms: 10,
-                uncompressed: false,
-                sorted: "all".to_string(),
-                zooms: None,
-                block_size: DEFAULT_BLOCK_SIZE,
-                items_per_slot: DEFAULT_ITEMS_PER_SLOT,
-                inmemory: false,
-            },
-        };
-
-        let result = bigtools::utils::cli::bedgraphtobigwig::bedgraphtobigwig(args);
-        if let Err(e) = result {
-            error!("Error converting bedGraph to BigWig: {e}");
-            anyhow::bail!("Conversion to BigWig failed");
+        // Get all chromsizes and apply scaffold filter.
+        let all_chromsizes = bam_stats.chromsizes_ref_name()?;
+        let mut chrom_sizes_vec = Vec::new();
+        for (name, len) in all_chromsizes {
+            if self.ignore_scaffold_chromosomes && is_scaffold(&name) {
+                continue;
+            }
+            let len_u32 = u32::try_from(len).context(format!(
+                "Chromosome {} length {} exceeds u32::MAX",
+                name, len
+            ))?;
+            chrom_sizes_vec.push((name, len_u32));
         }
-        // Clean up temporary files.
-        std::fs::remove_file(bedgraph_path)?;
-        std::fs::remove_file(chromsizes_path)?;
+        let chrom_sizes: std::collections::HashMap<String, u32> =
+            chrom_sizes_vec.into_iter().collect();
 
-        // Log success with file size.
-        if outfile.exists() {
-            let file_size = std::fs::metadata(&outfile)?.len();
-            info!(
-                "BigWig file successfully written: {} ({:.2} MB)",
-                outfile.display(),
-                file_size as f64 / 1_000_000.0
-            );
-        } else {
-            info!("BigWig file written to {}", outfile.display());
+        // Get normalized pileup as DataFrame.
+        let mut df = self.pileup_normalised()?;
+
+        // Filter scaffold chromosomes if requested.
+        if self.ignore_scaffold_chromosomes {
+            let mask = df
+                .column("chrom")?
+                .str()?
+                .iter()
+                .flatten()
+                .map(|s| !is_scaffold(s))
+                .collect::<BooleanChunked>();
+            df = df.filter(&mask)?;
         }
+
+        // Build chrom_idx mapping: chrom name → BAM header position.
+        let chrom_idx: HashMap<String, u32> = header
+            .reference_sequences()
+            .iter()
+            .enumerate()
+            .map(|(i, (name, _))| (String::from_utf8_lossy(name).to_string(), i as u32))
+            .collect();
+
+        // Add chrom_idx column to DataFrame.
+        let chrom_idx_col = df
+            .column("chrom")?
+            .str()?
+            .iter()
+            .flatten()
+            .map(|s| {
+                chrom_idx
+                    .get(s)
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Chromosome {} not in BAM header", s))
+            })
+            .collect::<Result<Vec<u32>>>()?;
+        df.with_column(Column::new("chrom_idx".into(), chrom_idx_col))?;
+
+        // Pre-cast start, end (u64 → u32) and score (f64 → f32) before sorting.
+        // Verify no overflow first.
+        let start_max = df.column("start")?.u64()?.max().unwrap_or(0);
+        let end_max = df.column("end")?.u64()?.max().unwrap_or(0);
+        let _start_max_u32 = u32::try_from(start_max).context("start position exceeds u32::MAX")?;
+        let _end_max_u32 = u32::try_from(end_max).context("end position exceeds u32::MAX")?;
+
+        df = df
+            .lazy()
+            .with_column(col("start").cast(DataType::UInt32))
+            .with_column(col("end").cast(DataType::UInt32))
+            .with_column(col("score").cast(DataType::Float32))
+            .collect()?;
+
+        // Sort by chrom_idx, then by start.
+        df = df.sort(["chrom_idx", "start"], SortMultipleOptions::default())?;
+
+        // Rechunk so column iterators are contiguous slices.
+        df.rechunk_mut();
+
+        // Get column slices.
+        let idx_slice = df.column("chrom_idx")?.u32()?.cont_slice()?;
+        let start_slice = df.column("start")?.u32()?.cont_slice()?;
+        let end_slice = df.column("end")?.u32()?.cont_slice()?;
+        let score_slice = df.column("score")?.f32()?.cont_slice()?;
+
+        // Build chrom_names indexed by BAM header position (for zero-alloc lookup in loop).
+        let mut chrom_names = vec!["".to_string(); chrom_idx.len()];
+        for (name, idx) in &chrom_idx {
+            chrom_names[*idx as usize] = name.clone();
+        }
+
+        // Create iterator from column slices: (chrom_name, Value).
+        let n_rows = df.height();
+        let iter = (0..n_rows).map(|i| {
+            let name: &str = chrom_names[idx_slice[i] as usize].as_str();
+            (
+                name,
+                Value {
+                    start: start_slice[i],
+                    end: end_slice[i],
+                    value: score_slice[i],
+                },
+            )
+        });
+
+        // Wrap in BedParserStreamingIterator.
+        let bed_iter = BedParserStreamingIterator::wrap_infallible_iter(iter, true);
+
+        // Create BigWigWrite and write.
+        let bw_writer = BigWigWrite::create_file(&outfile, chrom_sizes)?;
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(self.nthreads as usize)
+            .build()?;
+        bw_writer.write(bed_iter, runtime)?;
+
+        info!("BigWig file successfully written: {}", outfile.display());
         Ok(())
     }
 }
@@ -775,6 +855,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
     }
 
@@ -797,6 +878,7 @@ mod tests {
             BamReadFilter::default(),
             true,
             false,
+            None,
             None,
             None,
         );
@@ -884,6 +966,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         );
         let result = pileup.to_bigwig(output_path.clone());
         result.expect("Failed to create BigWig file");
@@ -916,6 +999,7 @@ mod tests {
             BamReadFilter::default(),
             true,
             false,
+            None,
             None,
             None,
         );
@@ -951,6 +1035,7 @@ mod tests {
             BamReadFilter::default(),
             false,
             false,
+            None,
             None,
             None,
         );

--- a/bamnado/src/main.rs
+++ b/bamnado/src/main.rs
@@ -130,6 +130,10 @@ struct CoverageOptions {
     /// Ignore scaffold chromosomes
     #[arg(long, action = clap::ArgAction::SetTrue)]
     ignore_scaffold: bool,
+
+    /// Number of threads to use for BigWig writing
+    #[arg(long, default_value = "6")]
+    threads: u32,
 }
 
 #[derive(Parser)]
@@ -502,6 +506,7 @@ fn main() -> Result<()> {
                 coverage_options.ignore_scaffold,
                 coverage_options.shift,
                 coverage_options.truncate,
+                Some(coverage_options.threads),
             );
 
             // Determine output file
@@ -627,6 +632,7 @@ fn main() -> Result<()> {
                     coverage_options.ignore_scaffold,
                     coverage_options.shift,
                     coverage_options.truncate,
+                    Some(coverage_options.threads),
                 ));
             }
 

--- a/bamnado/src/spike_in_analysis.rs
+++ b/bamnado/src/spike_in_analysis.rs
@@ -18,6 +18,8 @@ use crossbeam::channel::unbounded;
 use log::info;
 use noodles::{bam, sam};
 
+use crate::bam_utils::add_bamnado_program_group;
+
 /// Statistics for the read splitting process.
 ///
 /// Tracks the number of reads assigned to each category (endogenous, exogenous, etc.).
@@ -187,10 +189,10 @@ impl BamSplitter {
             }
         }
 
-        let header_endogenous = header_input.clone();
-        let header_exogenous = header_input.clone();
-        let header_both_genomes = header_input.clone();
-        let header_unmapped = header_input.clone();
+        let header_endogenous = add_bamnado_program_group(&header_input)?;
+        let header_exogenous = add_bamnado_program_group(&header_input)?;
+        let header_both_genomes = add_bamnado_program_group(&header_input)?;
+        let header_unmapped = add_bamnado_program_group(&header_input)?;
 
         let stats = SplitStats::new(
             input_path


### PR DESCRIPTION
This pull request introduces a new feature that ensures all BAM files written by the pipeline are annotated with a `@PG` (program group) record for reproducibility, making it clear that they were generated by bamnado and capturing version and command-line metadata. The implementation includes a utility for adding the program group, updates all BAM writing code to use headers with this annotation, and adds comprehensive tests to verify the behavior. Additionally, it introduces some code cleanup and small improvements to coverage analysis.

**BAM header annotation and propagation:**

* Added a new function `add_bamnado_program_group` in `bam_utils.rs` to append a `@PG` record with the program name, version, and command-line to BAM headers.
* Updated all BAM writing logic in `bam_modifier.rs` and `bam_splitter.rs` to use the annotated header, ensuring output files always include the `bamnado` program group. [[1]](diffhunk://#diff-c979acce260499b786a89cb410c31a3b1379920ab500c27d86d05dc1988e9635L9-R9) [[2]](diffhunk://#diff-c979acce260499b786a89cb410c31a3b1379920ab500c27d86d05dc1988e9635R66) [[3]](diffhunk://#diff-c979acce260499b786a89cb410c31a3b1379920ab500c27d86d05dc1988e9635L74-R75) [[4]](diffhunk://#diff-c979acce260499b786a89cb410c31a3b1379920ab500c27d86d05dc1988e9635L217-R225) [[5]](diffhunk://#diff-dbc3c8e5a331d6107fecccc12391e7fbf611c00b296c8a0f6871fc7423f05b56L12-R12) [[6]](diffhunk://#diff-dbc3c8e5a331d6107fecccc12391e7fbf611c00b296c8a0f6871fc7423f05b56R65) [[7]](diffhunk://#diff-dbc3c8e5a331d6107fecccc12391e7fbf611c00b296c8a0f6871fc7423f05b56L74-R74) [[8]](diffhunk://#diff-dbc3c8e5a331d6107fecccc12391e7fbf611c00b296c8a0f6871fc7423f05b56L102-R102) [[9]](diffhunk://#diff-dbc3c8e5a331d6107fecccc12391e7fbf611c00b296c8a0f6871fc7423f05b56R141-R154)
* Added and updated tests in both `bam_utils.rs` and `bam_splitter.rs` to verify that the output BAM headers contain the correct `@PG` record with the expected fields. [[1]](diffhunk://#diff-9065e702a25b4e674ccf926cae47f5caccb136be77478dcaaf112daa83e47e6aR759-R787) [[2]](diffhunk://#diff-dbc3c8e5a331d6107fecccc12391e7fbf611c00b296c8a0f6871fc7423f05b56R189-R238)

**Coverage analysis improvements:**

* Refactored scaffold chromosome filtering to use a static, thread-safe regex and a helper function, improving efficiency and code clarity. [[1]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bR12) [[2]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bL21-R39) [[3]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bL41-R55)
* Extended `BamPileup` to allow configuration of the number of threads used by the BigWig writer. [[1]](diffhunk://#diff-e2e5343861e0aad294bda43c73f6d41a2b05fa3ca56c5dea28b73cf68946d60cR284) [[2]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bR152-R153) [[3]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bR237) [[4]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bR250)

**Code cleanup:**

* Removed the unused `write_chromsizes` method from `BamStats` and added a convenience accessor for the header. [[1]](diffhunk://#diff-9065e702a25b4e674ccf926cae47f5caccb136be77478dcaaf112daa83e47e6aL493-L518) [[2]](diffhunk://#diff-9065e702a25b4e674ccf926cae47f5caccb136be77478dcaaf112daa83e47e6aR512-R516)


Fixes #57 