### PR TITLE
Enhance CLI with clearer command descriptions and improved help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changes in existing functionality
+- Refined CLI help output with clearer command descriptions, grouped option sections, and command examples.
+- Cleaned up several long option names while keeping backwards-compatible aliases, including `--normalize`, `--fragment-counts`, `--blacklist`, `--barcode-allowlist`, `--tag`, and fragment-length flags.
 
 ## [0.3.1] - 2025-07-09
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Useful in workflows including single-cell and Micro-Capture-C (MCC), and many ot
 - Read filtering by mapping quality, length, strand, fragment size, tags, and barcodes
 - BigWig comparison (subtraction, ratio, log-ratio)
 - BigWig aggregation (sum, mean, median, min, max)
-- `collapse-bedgraph` utility to merge adjacent bins with identical scores
+- bedGraph post-processing with `collapse-bedgraph`
 - Python bindings for selected functionality
 
 ## Installation
@@ -287,9 +287,14 @@ bamnado <command> --help            # Help for a specific command
 
 ### Available commands
 
-- **Coverage generation**: `bam-coverage`, `multi-bam-coverage`
+- **Coverage generation**: `bam-coverage` (`coverage`), `multi-bam-coverage` (`multi-coverage`)
 - **BAM manipulation**: `split`, `split-exogenous`, `modify`
-- **BigWig tools**: `bigwig-compare`, `bigwig-aggregate`, `collapse-bedgraph`
+- **BigWig tools**: `bigwig-compare` (`compare-bigwigs`), `bigwig-aggregate` (`aggregate-bigwigs`)
+- **bedGraph tools**: `collapse-bedgraph` (`collapse`)
+
+### Common naming cleanups
+
+The CLI now exposes shorter, more descriptive option names. Older names still work as compatibility aliases.
 
 ### Read filtering
 
@@ -298,16 +303,25 @@ All coverage commands share common read filter flags:
 | Flag | Default | Description |
 | ---- | ------- | ----------- |
 | `--strand` | `both` | `forward`, `reverse`, or `both` |
-| `--proper-pair` | off | Keep only properly-paired reads |
+| `--proper-pairs` | off | Keep only properly-paired reads |
 | `--min-mapq` | 20 | Minimum mapping quality |
 | `--min-length` | 20 | Minimum read length (bp) |
 | `--max-length` | 1000 | Maximum read length (bp) |
-| `--min-fragment-length` | — | Minimum insert size (bp); paired-end only |
-| `--max-fragment-length` | — | Maximum insert size (bp); paired-end only |
-| `--blacklisted-locations` | — | BED file of regions to exclude |
-| `--whitelisted-barcodes` | — | Text file of cell barcodes (one per line) |
+| `--min-fragment-len` | — | Minimum insert size (bp); paired-end only |
+| `--max-fragment-len` | — | Maximum insert size (bp); paired-end only |
+| `--blacklist` | — | BED file of regions to exclude |
+| `--barcode-allowlist` | — | Text file of cell barcodes (one per line) |
 | `--read-group` | — | Keep only this read group |
-| `--filter-tag` / `--filter-tag-value` | — | Keep reads where TAG == VALUE |
+| `--tag` / `--tag-value` | — | Keep reads where TAG == VALUE |
+
+### Coverage-specific flags
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--normalize` | `raw` | Signal normalization method: `raw`, `rpkm`, or `cpm` |
+| `--fragment-counts` | off | Count fragments instead of individual read alignments |
+| `--ignore-scaffolds` | off | Skip scaffold or unplaced chromosomes |
+| `--threads` | `6` | Threads used when writing BigWig output |
 
 ### Examples
 
@@ -327,9 +341,9 @@ bamnado bam-coverage \
   --bam sample.bam \
   --output coverage_hq.bw \
   --bin-size 100 \
-  --norm-method rpkm \
+  --normalize rpkm \
   --min-mapq 30 \
-  --proper-pair
+  --proper-pairs
 ```
 
 #### Extract nucleosome-free regions from ATAC-seq
@@ -340,9 +354,9 @@ bamnado bam-coverage \
   --output nfr_forward.bw \
   --bin-size 10 \
   --strand forward \
-  --min-fragment-length 100 \
-  --max-fragment-length 200 \
-  --use-fragment \
+  --min-fragment-len 100 \
+  --max-fragment-len 200 \
+  --fragment-counts \
   --min-mapq 20
 ```
 
@@ -353,8 +367,8 @@ bamnado bam-coverage \
   --bam possorted_genome_bam.bam \
   --output cell_coverage.bw \
   --bin-size 100 \
-  --whitelisted-barcodes barcodes.txt \
-  --use-fragment
+  --barcode-allowlist barcodes.txt \
+  --fragment-counts
 ```
 
 #### Filter by SAM tag (MCC viewpoint)
@@ -364,9 +378,9 @@ bamnado bam-coverage \
   --bam mcc.bam \
   --output BCL2_viewpoint.bw \
   --bin-size 50 \
-  --filter-tag "VP" \
-  --filter-tag-value "BCL2" \
-  --use-fragment \
+  --tag VP \
+  --tag-value BCL2 \
+  --fragment-counts \
   --min-mapq 30
 ```
 

--- a/bamnado/Cargo.toml
+++ b/bamnado/Cargo.toml
@@ -19,6 +19,7 @@ bio = "3.0.0"
 bio-types = "1.0.1"
 clap = {version = "4.5.53", features = ["derive"]}
 colog = "1.3.0"
+comfy-table = "7.2.1"
 indicatif = {version = "0.18.3", features = ["rayon"]}
 itertools = "0.14.0"
 log = "0.4.29"

--- a/bamnado/src/coverage_analysis.rs
+++ b/bamnado/src/coverage_analysis.rs
@@ -21,6 +21,10 @@ use anyhow::{Context, Result};
 use bigtools::BigWigRead;
 use bigtools::beddata::BedParserStreamingIterator;
 use bigtools::{BigWigWrite, Value};
+use comfy_table::{
+    Cell, CellAlignment, ContentArrangement, Table, modifiers::UTF8_ROUND_CORNERS,
+    presets::UTF8_FULL,
+};
 use indicatif::ParallelProgressIterator;
 use log::{debug, info};
 use noodles::bam;
@@ -36,6 +40,13 @@ fn is_scaffold(name: &str) -> bool {
     SCAFFOLD_REGEX
         .get_or_init(|| Regex::new("(chrUn.*|.*alt|.*random)").unwrap())
         .is_match(name)
+}
+
+fn shift_is_noop(shift: Shift) -> bool {
+    shift.five_prime == 0
+        && shift.three_prime == 0
+        && shift.five_prime_reverse == 0
+        && shift.three_prime_reverse == 0
 }
 
 /// Write a DataFrame as a bedGraph file (tab-separated, no header).
@@ -155,13 +166,68 @@ pub struct BamPileup {
 
 impl Display for BamPileup {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        writeln!(f, "Pileup Settings:")?;
-        writeln!(f, "BAM file: {}", self.file_path.display())?;
-        writeln!(f, "Bin size: {}", self.bin_size)?;
-        writeln!(f, "Normalization method: {:?}", self.norm_method)?;
-        writeln!(f, "Scaling factor: {}", self.scale_factor)?;
-        writeln!(f, "Using fragment for counting: {}", self.use_fragment)?;
-        write!(f, "Filtering using: \n{}\n", self.filter)
+        let counting_mode = if self.use_fragment {
+            "fragments"
+        } else {
+            "reads"
+        };
+        let stats = self.filter.stats();
+        let normalization_factor = if matches!(self.norm_method, NormalizationMethod::Raw)
+            || stats.n_reads_after_filtering() > 0
+        {
+            format!("{:.6}", self.normalization_factor())
+        } else {
+            "pending".to_string()
+        };
+        let mut rows = vec![
+            ("input", self.file_path.display().to_string()),
+            ("bin size", format!("{} bp", self.bin_size)),
+            ("normalization", format!("{:?}", self.norm_method)),
+            ("normalization factor", normalization_factor),
+            ("scale factor", format!("{:.3}", self.scale_factor)),
+            ("counting", counting_mode.to_string()),
+            ("output threads", self.nthreads.to_string()),
+            (
+                "scaffolds",
+                if self.ignore_scaffold_chromosomes {
+                    "ignored".to_string()
+                } else {
+                    "included".to_string()
+                },
+            ),
+        ];
+
+        if let Some(shift) = self.shift.filter(|shift| !shift_is_noop(*shift)) {
+            rows.push((
+                "shift",
+                format!(
+                    "{},{},{},{}",
+                    shift.five_prime,
+                    shift.three_prime,
+                    shift.five_prime_reverse,
+                    shift.three_prime_reverse
+                ),
+            ));
+        }
+        if let Some(truncate) = self.truncate {
+            rows.push(("truncate", format!("{truncate:?}")));
+        }
+
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_header(vec!["setting", "value"]);
+
+        for (label, value) in rows {
+            table.add_row(vec![
+                Cell::new(label),
+                Cell::new(value).set_alignment(CellAlignment::Right),
+            ]);
+        }
+
+        write!(f, "Coverage Run Details\n{table}")
     }
 }
 
@@ -255,12 +321,9 @@ impl BamPileup {
         // Calculate the normalization factor based on the normalization method.
         let filter_stats = self.filter.stats();
         let n_reads = filter_stats.n_reads_after_filtering();
-        let normalization_factor =
-            self.norm_method
-                .scale_factor(self.scale_factor, self.bin_size, n_reads);
-        // Log the normalization factor.
-        info!("Normalization factor: {normalization_factor}");
-        normalization_factor
+
+        self.norm_method
+            .scale_factor(self.scale_factor, self.bin_size, n_reads)
     }
 
     /// Generate pileup for a single chromosome.
@@ -510,10 +573,10 @@ impl BamPileup {
             .sum();
 
         info!(
-            "Pileup complete: {} chromosomes, {} total intervals, {} bp coverage",
+            "Pileup complete: {} chromosomes, {} intervals, {} bp spanned",
             n_chromosomes, total_intervals, total_bp_covered
         );
-        info!("Overall filtering statistics: {}", self.filter.stats());
+        info!("Read filtering: {}", self.filter.stats());
         self.log_filter_stats("Overall");
 
         Ok(pileup)
@@ -591,14 +654,14 @@ impl BamPileup {
     ///
     /// * `outfile` - The path to the output bedGraph file.
     pub fn to_bedgraph(&self, outfile: PathBuf) -> Result<()> {
-        info!("Writing bedGraph file to {}", outfile.display());
+        info!("Writing bedGraph to {}", outfile.display());
         let df = self.pileup_normalised()?;
         write_bedgraph(df, outfile.clone(), self.ignore_scaffold_chromosomes)?;
 
         if outfile.exists() {
             let file_size = std::fs::metadata(&outfile)?.len();
             info!(
-                "bedGraph file written: {} ({:.2} MB)",
+                "Wrote bedGraph: {} ({:.2} MB)",
                 outfile.display(),
                 file_size as f64 / 1_000_000.0
             );
@@ -728,7 +791,7 @@ impl BamPileup {
             .build()?;
         bw_writer.write(bed_iter, runtime)?;
 
-        info!("BigWig file successfully written: {}", outfile.display());
+        info!("Wrote BigWig: {}", outfile.display());
         Ok(())
     }
 }

--- a/bamnado/src/coverage_analysis.rs
+++ b/bamnado/src/coverage_analysis.rs
@@ -1004,12 +1004,18 @@ mod tests {
         let pileup = create_test_bam_pileup();
         let display_str = format!("{pileup}");
 
-        assert!(display_str.contains("Pileup Settings:"));
-        assert!(display_str.contains("BAM file: test.bam"));
-        assert!(display_str.contains("Bin size: 1000"));
-        assert!(display_str.contains("Normalization method:"));
-        assert!(display_str.contains("Scaling factor: 1"));
-        assert!(display_str.contains("Using fragment for counting: false"));
+        assert!(display_str.contains("Coverage Run Details"));
+        assert!(display_str.contains("input"));
+        assert!(display_str.contains("test.bam"));
+        assert!(display_str.contains("bin size"));
+        assert!(display_str.contains("1000 bp"));
+        assert!(display_str.contains("normalization"));
+        assert!(display_str.contains("Raw"));
+        assert!(display_str.contains("normalization factor"));
+        assert!(display_str.contains("1.000000"));
+        assert!(display_str.contains("scale factor"));
+        assert!(display_str.contains("counting"));
+        assert!(display_str.contains("reads"));
     }
 
     #[test]

--- a/bamnado/src/main.rs
+++ b/bamnado/src/main.rs
@@ -1,6 +1,10 @@
 use anyhow::{Context, Result};
 use bamnado::bam_utils::FileType;
 use clap::{Parser, Subcommand};
+use comfy_table::{
+    Cell, CellAlignment, ContentArrangement, Table, modifiers::UTF8_ROUND_CORNERS,
+    presets::UTF8_FULL,
+};
 use log::info;
 use polars::prelude::*;
 use std::str::FromStr;
@@ -50,113 +54,165 @@ pub fn get_styles() -> clap::builder::Styles {
 
 // Define common filter options as a trait to avoid code duplication
 #[derive(Parser, Clone)]
+#[command(next_help_heading = "Read Filters")]
 struct FilterOptions {
-    /// Filter reads based on strand
-    #[arg(long, default_value = "both")]
+    /// Count only reads from the selected strand.
+    #[arg(long, default_value = "both", value_name = "STRAND")]
     strand: bamnado::Strand,
 
-    /// Properly paired reads only
-    #[arg(long, action = clap::ArgAction::SetTrue)]
+    /// Keep only properly paired reads.
+    #[arg(
+        long = "proper-pairs",
+        visible_alias = "proper-pair",
+        action = clap::ArgAction::SetTrue
+    )]
     proper_pair: bool,
 
-    /// Minimum mapping quality
-    #[arg(long, required = false, default_value = "20")]
+    /// Minimum mapping quality.
+    #[arg(long, default_value = "20", value_name = "INT")]
     min_mapq: u8,
 
-    /// Minimum read length
-    #[arg(long, required = false, default_value = "20")]
+    /// Minimum read length in base pairs.
+    #[arg(long, default_value = "20", value_name = "BP")]
     min_length: u32,
 
-    /// Maximum read length
-    #[arg(long, required = false, default_value = "1000")]
+    /// Maximum read length in base pairs.
+    #[arg(long, default_value = "1000", value_name = "BP")]
     max_length: u32,
 
-    /// Blacklisted locations in BED format
-    #[arg(long, required = false)]
+    /// BED file of regions to exclude.
+    #[arg(
+        long = "blacklist",
+        visible_alias = "blacklisted-locations",
+        value_name = "BED"
+    )]
     blacklisted_locations: Option<PathBuf>,
 
-    /// Whitelisted barcodes in a text file (one barcode per line)
-    #[arg(long, required = false)]
+    /// Text file of barcodes to keep, one barcode per line.
+    #[arg(
+        long = "barcode-allowlist",
+        visible_alias = "whitelisted-barcodes",
+        value_name = "FILE"
+    )]
     whitelisted_barcodes: Option<PathBuf>,
 
-    /// Selected read group
-    #[arg(long, required = false)]
+    /// Keep only reads from this read group.
+    #[arg(long, value_name = "RG")]
     read_group: Option<String>,
 
-    /// Filter reads by SAM tag (e.g., VP, AS, etc.)
-    #[arg(long, required = false)]
+    /// Keep reads with this SAM tag.
+    #[arg(long = "tag", visible_alias = "filter-tag", value_name = "TAG")]
     filter_tag: Option<String>,
 
-    /// Value for the filter tag (e.g., BCL2, TP, etc.)
-    #[arg(long, required = false)]
+    /// Required value for `--tag`.
+    #[arg(
+        long = "tag-value",
+        visible_alias = "filter-tag-value",
+        value_name = "VALUE"
+    )]
     filter_tag_value: Option<String>,
 
-    /// Minimum fragment length (insert size / TLEN) in base pairs
-    #[arg(long, required = false)]
+    /// Minimum fragment length (TLEN) in base pairs.
+    #[arg(
+        long = "min-fragment-len",
+        visible_alias = "min-fragment-length",
+        value_name = "BP"
+    )]
     min_fragment_length: Option<u32>,
 
-    /// Maximum fragment length (insert size / TLEN) in base pairs
-    #[arg(long, required = false)]
+    /// Maximum fragment length (TLEN) in base pairs.
+    #[arg(
+        long = "max-fragment-len",
+        visible_alias = "max-fragment-length",
+        value_name = "BP"
+    )]
     max_fragment_length: Option<u32>,
 }
 
 // Common coverage options for both single and multi-BAM operations
 #[derive(Parser, Clone)]
+#[command(next_help_heading = "Coverage Options")]
 struct CoverageOptions {
-    /// Bin size for coverage calculation
-    #[arg(short = 's', long)]
+    /// Bin size for the output track.
+    #[arg(short = 's', long, value_name = "BP")]
     bin_size: Option<u64>,
 
-    /// Normalization method to use
-    #[arg(short, long, default_value = "raw")]
+    /// Signal normalization method.
+    #[arg(
+        short = 'n',
+        long = "normalize",
+        visible_alias = "norm-method",
+        default_value = "raw",
+        value_name = "METHOD"
+    )]
     norm_method: Option<bamnado::signal_normalization::NormalizationMethod>,
 
-    /// Scaling factor for the pileup
-    #[arg(short = 'f', long)]
+    /// Multiply the final signal by this factor.
+    #[arg(short = 'f', long, value_name = "FLOAT")]
     scale_factor: Option<f32>,
 
-    /// Use the fragment or the read for counting
-    #[arg(long, action = clap::ArgAction::SetTrue)]
+    /// Count fragments instead of individual read alignments.
+    #[arg(
+        long = "fragment-counts",
+        visible_alias = "use-fragment",
+        action = clap::ArgAction::SetTrue
+    )]
     use_fragment: bool,
 
-    /// Shift options for the pileup
-    #[arg(long, default_value = "0,0,0,0")]
+    /// Shift read or fragment ends before pileup.
+    #[arg(long, default_value = "0,0,0,0", value_name = "L,R,FL,FR")]
     shift: Option<bamnado::genomic_intervals::Shift>,
 
-    /// Truncate options for the pileup
-    #[arg(long)]
+    /// Trim read or fragment ends before pileup.
+    #[arg(long, value_name = "L,R,FL,FR")]
     truncate: Option<bamnado::genomic_intervals::Truncate>,
 
-    /// Ignore scaffold chromosomes
-    #[arg(long, action = clap::ArgAction::SetTrue)]
+    /// Skip scaffold or unplaced chromosomes.
+    #[arg(
+        long = "ignore-scaffolds",
+        visible_alias = "ignore-scaffold",
+        action = clap::ArgAction::SetTrue
+    )]
     ignore_scaffold: bool,
 
-    /// Number of threads to use for BigWig writing
-    #[arg(long, default_value = "6")]
+    /// Threads to use while writing BigWig output.
+    #[arg(long, default_value = "6", value_name = "N")]
     threads: u32,
 }
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None, styles=get_styles())]
+#[command(
+    author,
+    version,
+    about = "Fast BAM and BigWig utilities for genomics workflows.",
+    long_about = "Fast BAM and BigWig utilities for genomics workflows.\n\nUse `bamnado <command> --help` to see command-specific options and examples.",
+    styles = get_styles(),
+    arg_required_else_help = true
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
 
-    /// Verbosity level
-    #[arg(short, long, required = false, default_value = "2")]
+    /// Log verbosity from 0 (quiet) to 4 (debug).
+    #[arg(short, long, default_value = "2", global = true, value_name = "LEVEL")]
     verbose: u8,
 }
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Calculate coverage from a BAM file and write to a bedGraph or bigWig file
+    /// Generate a coverage track from one BAM file.
+    #[command(
+        name = "bam-coverage",
+        visible_alias = "coverage",
+        after_help = "Example:\n  bamnado bam-coverage --bam sample.bam --output sample.bw --bin-size 50 --normalize cpm"
+    )]
     BamCoverage {
-        /// Bam file for processing
-        #[arg(short, long)]
+        /// Input BAM file.
+        #[arg(short, long, value_name = "BAM")]
         bam: PathBuf,
 
-        /// Output file name
-        #[arg(short, long)]
+        /// Output bedGraph or BigWig path.
+        #[arg(short, long, value_name = "FILE")]
         output: Option<PathBuf>,
 
         #[command(flatten)]
@@ -166,14 +222,15 @@ enum Commands {
         filter_options: FilterOptions,
     },
 
-    /// Calculate coverage from multiple BAM files and write to a bedGraph or bigWig file
+    /// Merge coverage from multiple BAM files into one track.
+    #[command(name = "multi-bam-coverage", visible_alias = "multi-coverage")]
     MultiBamCoverage {
-        /// List of BAM files for processing
-        #[arg(short, long)]
+        /// Input BAM files.
+        #[arg(short, long, value_name = "BAM")]
         bams: Vec<PathBuf>,
 
-        /// Output file name
-        #[arg(short, long)]
+        /// Output bedGraph or BigWig path.
+        #[arg(short, long, value_name = "FILE")]
         output: Option<PathBuf>,
 
         #[command(flatten)]
@@ -183,106 +240,108 @@ enum Commands {
         filter_options: FilterOptions,
     },
 
-    /// Compare two BigWig files
-    #[command(name = "bigwig-compare")]
+    /// Compare two BigWig files bin by bin.
+    #[command(name = "bigwig-compare", visible_alias = "compare-bigwigs")]
     CompareBigWigs {
-        /// Path to the first BigWig file
-        #[arg(long)]
+        /// First BigWig input.
+        #[arg(long, value_name = "BW")]
         bw1: PathBuf,
 
-        /// Path to the second BigWig file
-        #[arg(long)]
+        /// Second BigWig input.
+        #[arg(long, value_name = "BW")]
         bw2: PathBuf,
 
-        /// Output BigWig file path
-        #[arg(short, long)]
+        /// Output BigWig path.
+        #[arg(short, long, value_name = "BW")]
         output: PathBuf,
 
-        /// Comparison method
-        #[arg(short, long, value_enum)]
+        /// Comparison method.
+        #[arg(short, long, value_enum, value_name = "METHOD")]
         comparison: bamnado::bigwig_compare::Comparison,
 
-        /// Bin size for comparison
-        #[arg(short = 's', long, default_value = "50")]
+        /// Bin size for comparison.
+        #[arg(short = 's', long, default_value = "50", value_name = "BP")]
         bin_size: u32,
 
-        /// Chunk size for processing
-        #[arg(long)]
+        /// Processing chunk size.
+        #[arg(long, value_name = "N")]
         chunk_size: Option<usize>,
 
-        #[arg(long)]
+        /// Value added to both tracks before comparison.
+        #[arg(long, value_name = "FLOAT")]
         pseudocount: Option<f64>,
     },
 
-    /// Aggregate multiple BigWig files into one
-    #[command(name = "bigwig-aggregate")]
+    /// Aggregate multiple BigWig files into one track.
+    #[command(name = "bigwig-aggregate", visible_alias = "aggregate-bigwigs")]
     AggregateBigWigs {
-        /// Paths to the BigWig files to aggregate
-        #[arg(long, num_args = 1..)]
+        /// BigWig files to aggregate.
+        #[arg(long, num_args = 1.., value_name = "BW")]
         bigwigs: Vec<PathBuf>,
 
-        /// Output BigWig file path
-        #[arg(short, long)]
+        /// Output BigWig path.
+        #[arg(short, long, value_name = "BW")]
         output: PathBuf,
 
-        /// Aggregation method
-        #[arg(short, long, value_enum)]
+        /// Aggregation method.
+        #[arg(short, long, value_enum, value_name = "METHOD")]
         method: bamnado::bigwig_compare::AggregationMode,
 
-        /// Bin size for aggregation
-        #[arg(short = 's', long, default_value = "50")]
+        /// Bin size for aggregation.
+        #[arg(short = 's', long, default_value = "50", value_name = "BP")]
         bin_size: u32,
 
-        /// Pseudocount value to add to all values
-        #[arg(long)]
+        /// Value added to all inputs before aggregation.
+        #[arg(long, value_name = "FLOAT")]
         pseudocount: Option<f64>,
     },
 
-    /// Collapse adjacent equal-score bins in a BedGraph
-    #[command(name = "collapse-bedgraph")]
+    /// Collapse adjacent equal-score bins in a bedGraph.
+    #[command(name = "collapse-bedgraph", visible_alias = "collapse")]
     CollapseBedgraph {
-        /// Input BedGraph file (defaults to stdin)
-        #[arg(short, long)]
+        /// Input bedGraph path. Reads from stdin if omitted.
+        #[arg(short, long, value_name = "BEDGRAPH")]
         input: Option<PathBuf>,
 
-        /// Output BedGraph file (defaults to stdout)
-        #[arg(short, long)]
+        /// Output bedGraph path. Writes to stdout if omitted.
+        #[arg(short, long, value_name = "BEDGRAPH")]
         output: Option<PathBuf>,
     },
 
-    /// Split a BAM file based on a set of defined filters
+    /// Split a BAM file using the supplied filters.
     Split {
-        /// Input BAM file
-        #[arg(short, long)]
+        /// Input BAM file.
+        #[arg(short, long, value_name = "BAM")]
         input: PathBuf,
 
-        /// Output prefix
-        #[arg(short, long)]
+        /// Output prefix.
+        #[arg(short, long, value_name = "PREFIX")]
         output: PathBuf,
 
         #[command(flatten)]
         filter_options: FilterOptions,
     },
 
-    /// Split a BAM file into endogenous and exogenous reads
+    /// Split a BAM file into endogenous and exogenous reads.
+    #[command(visible_alias = "split-spikein")]
     SplitExogenous {
-        /// Input BAM file
-        #[arg(short, long)]
+        /// Input BAM file.
+        #[arg(short, long, value_name = "BAM")]
         input: PathBuf,
 
-        /// Output prefix
-        #[arg(short, long)]
+        /// Output prefix.
+        #[arg(short, long, value_name = "PREFIX")]
         output: PathBuf,
 
-        /// Prefix for exogenous sequences
-        #[arg(short, long)]
+        /// Reference-name prefix used to identify exogenous sequences.
+        #[arg(short, long, value_name = "PREFIX")]
         exogenous_prefix: String,
 
-        /// Path for stats output
-        #[arg(short, long)]
+        /// Optional path for summary statistics output.
+        #[arg(short, long, value_name = "FILE")]
         stats: Option<PathBuf>,
 
-        /// Allow unknown MAPQ values - useful for BAM files with MAPQ=255 i.e. STAR generated BAM files
+        /// Allow reads with MAPQ 255, which is common in STAR output.
         #[arg(long, action = clap::ArgAction::SetTrue)]
         allow_unknown_mapq: bool,
 
@@ -290,20 +349,21 @@ enum Commands {
         filter_options: FilterOptions,
     },
 
-    /// Filter and/or adjust reads in a BAM file e.g. shift for Tn5 insertion
+    /// Filter and/or adjust reads in a BAM file.
     Modify {
-        /// Input BAM file
-        #[arg(short, long)]
+        /// Input BAM file.
+        #[arg(short, long, value_name = "BAM")]
         input: PathBuf,
 
-        /// Output prefix
-        #[arg(short, long)]
+        /// Output prefix.
+        #[arg(short, long, value_name = "PREFIX")]
         output: PathBuf,
 
-        /// Reads to ignore during modification
+        /// Reads to exclude before modification.
         #[command(flatten)]
         filter_options: FilterOptions,
 
+        /// Apply the standard Tn5 offset.
         #[arg(long, action = clap::ArgAction::SetTrue)]
         tn5_shift: bool,
     },
@@ -330,44 +390,70 @@ fn validate_bam_file(bam_path: &Path) -> Result<()> {
 }
 
 fn log_active_filters(filter_options: &FilterOptions) {
-    info!("=== Active Filters ===");
-    info!("Strand: {}", filter_options.strand);
-    if filter_options.proper_pair {
-        info!("Proper pair: enabled");
-    }
-    info!("Min MAPQ: {}", filter_options.min_mapq);
-    info!(
-        "Read length: {} - {} bp",
-        filter_options.min_length, filter_options.max_length
-    );
-    if let Some(blacklist) = &filter_options.blacklisted_locations {
-        info!("Blacklist: {}", blacklist.display());
-    }
-    if let Some(whitelist) = &filter_options.whitelisted_barcodes {
-        info!("Whitelisted barcodes: {}", whitelist.display());
-    }
-    if let Some(rg) = &filter_options.read_group {
-        info!("Read group: {}", rg);
-    }
-    if let Some(tag) = &filter_options.filter_tag {
-        info!(
-            "Filter tag: {} = {}",
-            tag,
-            filter_options.filter_tag_value.as_deref().unwrap_or("*")
-        );
-    }
+    let mut rows = vec![
+        ("strand", filter_options.strand.to_string()),
+        ("min MAPQ", filter_options.min_mapq.to_string()),
+        (
+            "read length",
+            format!(
+                "{}..{} bp",
+                filter_options.min_length, filter_options.max_length
+            ),
+        ),
+        (
+            "proper pairs",
+            if filter_options.proper_pair {
+                "required".to_string()
+            } else {
+                "off".to_string()
+            },
+        ),
+    ];
+
     if filter_options.min_fragment_length.is_some() || filter_options.max_fragment_length.is_some()
     {
-        info!(
-            "Fragment length: {} - {} bp",
-            filter_options
-                .min_fragment_length
-                .map_or(String::from("0"), |v| v.to_string()),
-            filter_options
-                .max_fragment_length
-                .map_or(String::from("∞"), |v| v.to_string())
-        );
+        rows.push((
+            "fragment length",
+            format!(
+                "{}..{} bp",
+                filter_options
+                    .min_fragment_length
+                    .map_or(String::from("0"), |v| v.to_string()),
+                filter_options
+                    .max_fragment_length
+                    .map_or(String::from("inf"), |v| v.to_string())
+            ),
+        ));
     }
+    if let Some(blacklist) = &filter_options.blacklisted_locations {
+        rows.push(("blacklist", blacklist.display().to_string()));
+    }
+    if let Some(whitelist) = &filter_options.whitelisted_barcodes {
+        rows.push(("barcode allowlist", whitelist.display().to_string()));
+    }
+    if let Some(rg) = &filter_options.read_group {
+        rows.push(("read group", rg.clone()));
+    }
+    if let Some(tag) = &filter_options.filter_tag {
+        let value = filter_options.filter_tag_value.as_deref().unwrap_or("*");
+        rows.push(("tag", format!("{tag}={value}")));
+    }
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec!["filter", "value"]);
+
+    for (label, value) in rows {
+        table.add_row(vec![
+            Cell::new(label),
+            Cell::new(value).set_alignment(CellAlignment::Right),
+        ]);
+    }
+
+    info!("Read Filter Settings\n{table}");
 }
 
 fn create_filter_from_options(
@@ -424,8 +510,6 @@ fn create_filter_from_options(
                      paired-end data."
         ));
     }
-
-    println!("Blacklisted locations: {blacklisted_locations:?}");
 
     Ok(bamnado::read_filter::BamReadFilter::new(
         filter_options.strand.into(),
@@ -539,8 +623,6 @@ fn main() -> Result<()> {
                     ));
                 }
             }
-
-            info!("Successfully wrote output");
         }
 
         Commands::MultiBamCoverage {

--- a/bamnado/src/read_filter.rs
+++ b/bamnado/src/read_filter.rs
@@ -11,6 +11,9 @@
 
 use ahash::{HashMap, HashSet};
 use anyhow::{Context, Result};
+use comfy_table::{
+    Cell, ContentArrangement, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL,
+};
 use noodles::sam;
 use noodles::sam::alignment::record::data::field::Value;
 use noodles::sam::alignment::record::data::field::tag::Tag;
@@ -105,38 +108,105 @@ pub struct BamReadFilterStatsSnapshot {
 
 impl Display for BamReadFilterStatsSnapshot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f)?;
-        writeln!(f, "Total reads: {}", self.n_total)?;
-        writeln!(f, "Failed proper pair: {}", self.n_failed_proper_pair)?;
-        writeln!(f, "Failed mapping quality: {}", self.n_failed_mapq)?;
-        writeln!(f, "Failed length: {}", self.n_failed_length)?;
-        writeln!(f, "Failed blacklist: {}", self.n_failed_blacklist)?;
-        writeln!(f, "Failed barcode: {}", self.n_failed_barcode)?;
-        writeln!(f, "Not in read group: {}", self.n_not_in_read_group)?;
-        writeln!(f, "Incorrect strand: {}", self.n_incorrect_strand)?;
-        writeln!(f, "Failed tag filter: {}", self.n_failed_tag_filter)?;
-        writeln!(
-            f,
-            "Failed fragment length: {}",
-            self.n_failed_fragment_length
-        )?;
-        writeln!(
-            f,
-            "Filtered reads: {}",
-            self.n_failed_proper_pair
-                + self.n_failed_mapq
-                + self.n_failed_length
-                + self.n_failed_blacklist
-                + self.n_failed_barcode
-                + self.n_not_in_read_group
-                + self.n_incorrect_strand
-                + self.n_failed_tag_filter
-                + self.n_failed_fragment_length
-        )
+        let rows = self.stage_rows();
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_header(vec!["stage", "remain", "drop", "% total"]);
+
+        for (label, remain, dropped, pct) in rows {
+            let dropped = if dropped == 0 {
+                "-".to_string()
+            } else {
+                format!("-{}", Self::format_count(dropped))
+            };
+
+            table.add_row(vec![
+                Cell::new(label),
+                Cell::new(Self::format_count(remain))
+                    .set_alignment(comfy_table::CellAlignment::Right),
+                Cell::new(dropped).set_alignment(comfy_table::CellAlignment::Right),
+                Cell::new(format!("{pct:.1}%")).set_alignment(comfy_table::CellAlignment::Right),
+            ]);
+        }
+
+        writeln!(f, "Read Filtering Funnel")?;
+        write!(f, "{table}")?;
+
+        Ok(())
     }
 }
 
 impl BamReadFilterStatsSnapshot {
+    fn format_count(count: u64) -> String {
+        let digits = count.to_string();
+        let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+        for (i, ch) in digits.chars().rev().enumerate() {
+            if i > 0 && i % 3 == 0 {
+                out.push(',');
+            }
+            out.push(ch);
+        }
+        out.chars().rev().collect()
+    }
+
+    /// Returns the number of reads filtered out.
+    pub fn n_filtered(&self) -> u64 {
+        self.n_total - self.n_reads_after_filtering()
+    }
+
+    /// Returns the percentage of reads that passed filtering.
+    pub fn pass_rate(&self) -> f64 {
+        if self.n_total == 0 {
+            0.0
+        } else {
+            (self.n_reads_after_filtering() as f64 / self.n_total as f64) * 100.0
+        }
+    }
+
+    fn pct_of_total(&self, count: u64) -> f64 {
+        if self.n_total == 0 {
+            0.0
+        } else {
+            (count as f64 / self.n_total as f64) * 100.0
+        }
+    }
+
+    /// Returns rows for a staged read-filtering summary.
+    pub fn stage_rows(&self) -> Vec<(&'static str, u64, u64, f64)> {
+        let mut remaining = self.n_total;
+        let mut rows = vec![("Initial reads", remaining, 0, 100.0)];
+
+        let failures = [
+            ("Pass strand filter", self.n_incorrect_strand),
+            ("Pass proper-pair filter", self.n_failed_proper_pair),
+            ("Pass minimum MAPQ", self.n_failed_mapq),
+            ("Pass read-length filter", self.n_failed_length),
+            ("Pass fragment-length filter", self.n_failed_fragment_length),
+            ("Outside blacklist", self.n_failed_blacklist),
+            ("Pass barcode allowlist", self.n_failed_barcode),
+            ("Pass read-group filter", self.n_not_in_read_group),
+            ("Pass tag filter", self.n_failed_tag_filter),
+        ];
+
+        for (label, dropped) in failures {
+            if dropped > 0 {
+                remaining -= dropped;
+                rows.push((label, remaining, dropped, self.pct_of_total(remaining)));
+            }
+        }
+
+        rows.push((
+            "Reads retained",
+            self.n_reads_after_filtering(),
+            0,
+            self.pass_rate(),
+        ));
+        rows
+    }
+
     /// Returns the number of reads remaining after filtering.
     pub fn n_reads_after_filtering(&self) -> u64 {
         self.n_total
@@ -397,6 +467,9 @@ impl BamReadFilter {
 
         // Filter by proper pair.
         if self.proper_pair && !flags.is_properly_segmented() {
+            self.stats
+                .n_failed_proper_pair
+                .fetch_add(1, Ordering::Relaxed);
             return Ok(false);
         }
 


### PR DESCRIPTION
This pull request significantly improves the usability and clarity of the `bamnado` command-line interface (CLI) and its documentation. The changes focus on making command options easier to understand and use, providing more helpful help output, and modernizing the summary and logging output for users. Backwards compatibility is maintained through aliases for older option names.

**CLI and Documentation Improvements:**

* Refined CLI help output with clearer command descriptions, grouped option sections, and command examples. Option names are now shorter and more descriptive, with old names preserved as compatibility aliases. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL22-R23) `README.md` [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L290-R297) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L301-R324) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L330-R346) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L343-R359) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L356-R371) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L367-R383) `bamnado/src/main.rs` [[8]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cR57-R215) [[9]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cL169-R233)

* Updated documentation and examples to use the new, cleaner option names and show grouped commands and options. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L290-R297) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L301-R324) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L330-R346) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L343-R359) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L356-R371) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L367-R383)

**Code and Output Modernization:**

* Introduced the `comfy-table` crate to present run settings and statistics in a modern, easy-to-read table format when displaying `BamPileup` configuration and results. (`bamnado/Cargo.toml` [[1]](diffhunk://#diff-f5fb5aaedee8b28121dd76d083de8a9a37246af79248b2089ff894133a2c5f35R22) `bamnado/src/coverage_analysis.rs` [[2]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bR24-R27) [[3]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bL158-R230) `bamnado/src/main.rs` [[4]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cR4-R7)

* Improved log and output messages for file writing and filtering statistics to be more concise and user-friendly. (`bamnado/src/coverage_analysis.rs` [[1]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bL513-R579) [[2]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bL594-R664) [[3]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bL731-R794)

**Internal Refactoring and Consistency:**

* Cleaned up and standardized internal flag handling, normalization factor calculation, and function naming for clarity and maintainability. (`bamnado/src/coverage_analysis.rs` [[1]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bR45-R51) [[2]](diffhunk://#diff-cc88cfbc6df479c6d396ae1c0d3b496f3938976201c434d178dfebf9c269624bL258-R326)

These changes make `bamnado` easier to use for both new and experienced users, improve the clarity of its output, and set the stage for future enhancements.