### PR TITLE
Enhance infer scale functionality with JSON output options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,4 @@ maturin build --release  # wheel
 #### Repo notes:
 
 - Main branch has protection, needs a PR to merge.
+- `cargo build` (workspace) fails at link stage with pyo3 undefined symbol errors (`_PyBaseObject_Type`, etc.) — Python headers not linked in the dev environment. Use `cargo build -p bamnado` or `cargo test -p bamnado` to build/test the Rust library and CLI without the Python bindings. The pyo3 cdylib in `bamnado-python/` requires `maturin` to build correctly.

--- a/bamnado/src/bigwig_infer_scale.rs
+++ b/bamnado/src/bigwig_infer_scale.rs
@@ -37,6 +37,39 @@ where
     }
 }
 
+/// Tuning knobs for `infer_scale_factor`.
+#[derive(Debug, Clone)]
+pub struct InferScaleConfig {
+    /// Stop scanning a chromosome after this many consecutive intervals with no new minimum.
+    ///
+    /// The heuristic is safe when the minimum bin value appears within the first
+    /// `min_stable_streak` intervals of a chromosome.  For real normalised BigWigs
+    /// (CPM/RPKM) single-read bins are scattered throughout the genome, so 50 000 is
+    /// conservative.  Set to `u32::MAX` to disable early exit and always do a full scan.
+    ///
+    /// **Limitation**: if ALL minimum bins are clustered at the very end of a chromosome
+    /// and the chromosome also contains two or more distinct larger values before that
+    /// point, the heuristic may report a higher minimum.  This is unlikely in practice
+    /// but can be demonstrated with synthetic data — see `test_heuristic_misses_late_minimum`.
+    pub min_stable_streak: u32,
+
+    /// Maximum number of interval start positions collected for bin-size (GCD) inference.
+    ///
+    /// The GCD of bin-aligned start positions stabilises within the first few entries.
+    /// Capping avoids O(intervals) `HashSet` growth on high-depth files where nearly
+    /// every bin is non-zero.
+    pub max_starts: usize,
+}
+
+impl Default for InferScaleConfig {
+    fn default() -> Self {
+        Self {
+            min_stable_streak: 50_000,
+            max_starts: 512,
+        }
+    }
+}
+
 /// Inferred normalisation method.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum NormMethod {
@@ -59,7 +92,7 @@ impl std::fmt::Display for NormMethod {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct Warnings {
     /// More than 2 distinct interval widths — variable bin sizes found.
     pub variable_bin_sizes: bool,
@@ -69,6 +102,34 @@ pub struct Warnings {
     pub pseudocount_detected: bool,
     /// Minimum value came from a chromosome that is < 0.1 % of genome size.
     pub min_from_small_chrom: bool,
+}
+
+impl Warnings {
+    /// Returns active warnings as human-readable strings (empty when no warnings).
+    pub fn messages(&self) -> Vec<&'static str> {
+        let mut v = Vec::new();
+        if self.variable_bin_sizes {
+            v.push("variable_bin_sizes: mixed bin widths detected, RPKM reversal unreliable");
+        }
+        if self.smoothing_detected {
+            v.push("smoothing_detected: ratio non-integer, recovery is approximate");
+        }
+        if self.pseudocount_detected {
+            v.push("pseudocount_detected: scale factor corrected to second_min");
+        }
+        if self.min_from_small_chrom {
+            v.push(
+                "min_from_small_chrom: minimum from small/unplaced chromosome, may be artefactual",
+            );
+        }
+        v
+    }
+}
+
+impl Serialize for Warnings {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.messages().serialize(s)
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -122,7 +183,7 @@ impl InferScaleResult {
 /// parallel — every worker thread opens its own buffered reader.  Scanning stops
 /// as soon as the minimum value has been confirmed on ≥2 chromosomes and the
 /// second_min/min ratio is near an integer.
-pub fn infer_scale_factor(bw_path: &Path) -> Result<InferScaleResult> {
+pub fn infer_scale_factor(bw_path: &Path, config: &InferScaleConfig) -> Result<InferScaleResult> {
     let chrom_info: Vec<bigtools::ChromInfo> = {
         let reader = open_bw(bw_path)?;
         reader.chroms().to_owned()
@@ -162,7 +223,7 @@ pub fn infer_scale_factor(bw_path: &Path) -> Result<InferScaleResult> {
             .par_iter()
             .map(|chrom| {
                 let mut r = open_bw(bw_path)?;
-                let (cmin, c2min, cwidths) = scan_chrom(&mut r, &chrom.name, chrom.length)?;
+                let (cmin, c2min, cwidths) = scan_chrom(&mut r, &chrom.name, chrom.length, config)?;
                 Ok((chrom.name.clone(), cmin, c2min, cwidths))
             })
             .collect();
@@ -300,11 +361,21 @@ fn scan_chrom<R: Read + Seek>(
     reader: &mut bigtools::BigWigRead<R>,
     chrom: &str,
     chrom_len: u32,
+    config: &InferScaleConfig,
 ) -> Result<(f64, f64, HashSet<u32>)> {
     let it = reader.get_interval(chrom, 0, chrom_len)?;
     let mut min1 = f64::MAX;
     let mut min2 = f64::MAX;
     let mut starts: HashSet<u32> = HashSet::new();
+    // Counts intervals since the last time min1 changed.  Once this exceeds
+    // min_stable_streak we have seen enough of the distribution to trust min1/min2.
+    //
+    // IMPORTANT: the break only fires when min2 < f64::MAX (i.e. we have already
+    // seen two distinct values), which prevents exiting on a single-value plateau.
+    // However, if a lower minimum exists beyond the streak window AND the chromosome
+    // already has two distinct values, it will be missed.  Use min_stable_streak =
+    // u32::MAX to disable this optimisation and always do a full scan.
+    let mut stable_streak: u32 = 0;
 
     for r in it {
         let iv = r?;
@@ -313,21 +384,28 @@ fn scan_chrom<R: Read + Seek>(
         }
         let v = iv.value as f64;
 
-        // Track non-zero start positions for bin_size inference.
-        // All intervals in a fixed-bin BigWig start at multiples of bin_size, including
-        // end-truncated ones — so starts are robust to chromosome boundary truncation.
-        // start=0 contributes nothing to GCD (identity), so skip it.
-        if iv.start > 0 {
+        // Collect start positions for bin_size inference via GCD.
+        // GCD stabilises within the first few multiples-of-bin_size entries,
+        // so stop inserting once we have enough — avoids O(intervals) HashSet growth
+        // on high-depth files where most bins are non-zero.
+        if iv.start > 0 && starts.len() < config.max_starts {
             starts.insert(iv.start);
         }
 
-        if v < min1 {
+        if v < min1 - 1e-9 {
             if min1 < min2 {
                 min2 = min1;
             }
             min1 = v;
-        } else if v > min1 + 1e-9 && v < min2 {
-            min2 = v;
+            stable_streak = 0;
+        } else {
+            if v > min1 + 1e-9 && v < min2 {
+                min2 = v;
+            }
+            stable_streak += 1;
+            if stable_streak >= config.min_stable_streak && min2 < f64::MAX {
+                break;
+            }
         }
     }
 
@@ -397,56 +475,58 @@ mod tests {
         Ok(())
     }
 
+    fn default_config() -> InferScaleConfig {
+        InferScaleConfig::default()
+    }
+
+    fn full_scan_config() -> InferScaleConfig {
+        InferScaleConfig {
+            min_stable_streak: u32::MAX,
+            ..InferScaleConfig::default()
+        }
+    }
+
     // ─── chrom_priority unit tests ───────────────────────────────────────────
 
     #[test]
     fn test_priority_mid_sized_autosome() {
-        // 10% of genome → mid-sized
         assert_eq!(chrom_priority("chr5", 1000, 10000), 0);
     }
 
     #[test]
     fn test_priority_large_chrom() {
-        // 30% of genome → large
         assert_eq!(chrom_priority("chr1", 3000, 10000), 1);
     }
 
     #[test]
     fn test_priority_small_chrom() {
-        // 1% of genome, no special name → small
         assert_eq!(chrom_priority("chr22", 100, 10000), 2);
     }
 
     #[test]
     fn test_priority_mito_name() {
-        // chrM is always deprioritised regardless of fraction
         assert_eq!(chrom_priority("chrM", 1000, 10000), 2);
         assert_eq!(chrom_priority("MT", 1000, 10000), 2);
     }
 
     #[test]
     fn test_priority_unplaced_scaffold() {
-        // Underscore in name → unplaced
         assert_eq!(chrom_priority("chr1_random", 1000, 10000), 2);
         assert_eq!(chrom_priority("chrUn_gl000220", 500, 10000), 2);
     }
 
     #[test]
     fn test_priority_zero_genome_size() {
-        // Degenerate — return 1 (not 0, not 2)
         assert_eq!(chrom_priority("chr1", 1000, 0), 1);
     }
 
     #[test]
     fn test_priority_tiny_fraction() {
-        // < 0.1% of genome → deprioritised even without special name
         assert_eq!(chrom_priority("chrSmall", 1, 1_000_000), 2);
     }
 
     // ─── infer_scale_factor integration tests ────────────────────────────────
 
-    /// Build a BigWig where the same minimum value appears on two chromosomes.
-    /// Standard parameters: bin_size=10, N_total=10M reads.
     fn make_two_chrom_bigwig(
         dir: &tempfile::TempDir,
         min_val: f32,
@@ -454,14 +534,13 @@ mod tests {
         bin_size: u32,
     ) -> anyhow::Result<std::path::PathBuf> {
         let path = dir.path().join("test.bw");
-        let chrom_len: u32 = bin_size * 20; // 20 bins each
+        let chrom_len: u32 = bin_size * 20;
         let mut chroms = HashMap::new();
         chroms.insert("chr5".to_string(), chrom_len);
         chroms.insert("chr7".to_string(), chrom_len);
 
         let mut intervals: Vec<(String, u32, u32, f32)> = Vec::new();
         for chrom in &["chr5", "chr7"] {
-            // One singleton bin (min_val), rest doublet (second_val)
             intervals.push((chrom.to_string(), 0, bin_size, min_val));
             for i in 1..20u32 {
                 intervals.push((
@@ -472,17 +551,15 @@ mod tests {
                 ));
             }
         }
-        // Intervals must be sorted per chrom — they already are.
         make_bigwig(&path, chroms, intervals)?;
         Ok(path)
     }
 
     #[test]
     fn test_cpm_detection() -> anyhow::Result<()> {
-        // N=100M, bin_size=10: min_val=0.01, n_cpm=100M ✓, n_rpkm=10B ✗ → CPM
         let dir = tempfile::tempdir()?;
         let path = make_two_chrom_bigwig(&dir, 0.01, 0.02, 10)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
 
         assert_eq!(r.norm_method, NormMethod::Cpm);
         assert!((r.scale_factor - 100.0).abs() < 1.0, "scale_factor ≈ 100");
@@ -498,10 +575,9 @@ mod tests {
 
     #[test]
     fn test_rpkm_detection() -> anyhow::Result<()> {
-        // N=10M, bin_size=10: min_val=10.0, n_cpm=100K ✗, n_rpkm=10M ✓ → RPKM
         let dir = tempfile::tempdir()?;
         let path = make_two_chrom_bigwig(&dir, 10.0, 20.0, 10)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
 
         assert_eq!(r.norm_method, NormMethod::Rpkm);
         assert!((r.scale_factor - 0.1).abs() < 0.001, "scale_factor ≈ 0.1");
@@ -514,42 +590,27 @@ mod tests {
 
     #[test]
     fn test_raw_unknown_detection_exits_quickly() -> anyhow::Result<()> {
-        // Raw count data: min_val=1000.0 (not plausible for CPM or RPKM).
-        // Confident after 2 chroms → early exit without scanning remaining genome.
         let dir = tempfile::tempdir()?;
         let path = make_two_chrom_bigwig(&dir, 1000.0, 2000.0, 10)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
 
         assert_eq!(r.norm_method, NormMethod::Unknown);
-        assert!(r.confident, "should exit confidently after 2 chroms");
-        assert_eq!(
-            r.chroms_scanned, 2,
-            "early exit after 2 confirmation chroms"
-        );
+        assert!(r.confident);
+        assert_eq!(r.chroms_scanned, 2);
         assert!((r.ratio - 2.0).abs() < 0.01);
         Ok(())
     }
 
     #[test]
     fn test_pseudocount_detected() -> anyhow::Result<()> {
-        // p=0.5: ratio = (1+p)/p = 3.0 > 2 and integer.
-        // min = p/N*1e6 = 0.5/8M*1e6 = 0.0625 (exact f32 = 1/16)
-        // second = (1+p)/N*1e6 = 1.5/8M*1e6 = 0.1875 (exact f32 = 3/16)
         let dir = tempfile::tempdir()?;
         let path = make_two_chrom_bigwig(&dir, 0.0625, 0.1875, 10)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
 
-        assert!(
-            r.warnings.pseudocount_detected,
-            "pseudocount should be flagged"
-        );
+        assert!(r.warnings.pseudocount_detected);
         let p = r.pseudocount.expect("pseudocount should be Some");
         assert!((p - 0.5).abs() < 0.01, "p ≈ 0.5, got {p}");
-        // Corrected scale_factor = 1/second_min = 1/0.1875 ≈ 5.333
-        assert!(
-            (r.scale_factor - (1.0 / 0.1875)).abs() < 0.01,
-            "s_corrected = 1/second_min"
-        );
+        assert!((r.scale_factor - (1.0 / 0.1875)).abs() < 0.01);
         assert!((r.ratio - 3.0).abs() < 0.01);
         assert!(r.confident);
         Ok(())
@@ -557,28 +618,23 @@ mod tests {
 
     #[test]
     fn test_smoothing_detected() -> anyhow::Result<()> {
-        // Non-integer ratio (1.5): fractional read contributions / kernel smoothing.
-        // min=0.25 (exact f32), second=0.375 (exact f32=3/8), ratio=1.5
         let dir = tempfile::tempdir()?;
         let path = make_two_chrom_bigwig(&dir, 0.25, 0.375, 10)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
 
-        assert!(r.warnings.smoothing_detected, "smoothing should be flagged");
-        assert!(!r.confident, "non-integer ratio → not confident");
+        assert!(r.warnings.smoothing_detected);
+        assert!(!r.confident);
         assert!((r.ratio - 1.5).abs() < 0.05);
         Ok(())
     }
 
     #[test]
     fn test_variable_bin_sizes_warning() -> anyhow::Result<()> {
-        // Non-zero start positions 10 and 21 → GCD(10,21)=1 → variable_bin_sizes warning.
-        // Simulates a file where two incommensurable bin grids are mixed.
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("varbins.bw");
         let mut chroms = HashMap::new();
         chroms.insert("chr5".to_string(), 50u32);
         chroms.insert("chr7".to_string(), 50u32);
-        // Non-zero starts visible after skipping start=0: {10, 21} → GCD=1 → variable.
         let intervals = vec![
             ("chr5".to_string(), 0u32, 10u32, 0.01f32),
             ("chr5".to_string(), 10, 21, 0.02),
@@ -588,19 +644,14 @@ mod tests {
             ("chr7".to_string(), 21, 50, 0.02),
         ];
         make_bigwig(&path, chroms, intervals)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
 
-        assert!(
-            r.warnings.variable_bin_sizes,
-            "coprime starts should flag variable_bin_sizes"
-        );
+        assert!(r.warnings.variable_bin_sizes);
         Ok(())
     }
 
     #[test]
     fn test_collapsed_bins_not_variable() -> anyhow::Result<()> {
-        // Collapsed BigWig: widths 10, 20, 30 (all ×10), starts {10, 30, 60}.
-        // GCD({10,30,60}) = 10 → canonical_bin_size=10, variable_bin_sizes=false.
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("collapsed.bw");
         let mut chroms = HashMap::new();
@@ -614,22 +665,18 @@ mod tests {
             intervals.push((chrom.to_string(), 60, 200, 0.02));
         }
         make_bigwig(&path, chroms, intervals)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
 
-        assert!(
-            !r.warnings.variable_bin_sizes,
-            "all-multiple starts should not trigger variable warning"
-        );
-        assert_eq!(r.bin_size, 10, "GCD of starts {{10,30,60}} = 10");
+        assert!(!r.warnings.variable_bin_sizes);
+        assert_eq!(r.bin_size, 10);
         Ok(())
     }
 
     #[test]
     fn test_confident_after_two_chroms() -> anyhow::Result<()> {
-        // Same min on 2 chroms + integer ratio → confident=true, scan stops at 2.
         let dir = tempfile::tempdir()?;
         let path = make_two_chrom_bigwig(&dir, 0.01, 0.02, 10)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
 
         assert!(r.confident);
         assert_eq!(r.chroms_scanned, 2);
@@ -638,7 +685,6 @@ mod tests {
 
     #[test]
     fn test_not_confident_single_chrom() -> anyhow::Result<()> {
-        // Only one chromosome → confirmations=1 → confident=false.
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("single.bw");
         let mut chroms = HashMap::new();
@@ -648,7 +694,7 @@ mod tests {
             ("chr5".to_string(), 10, 20, 0.02),
         ];
         make_bigwig(&path, chroms, intervals)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
 
         assert!(!r.confident);
         assert_eq!(r.chroms_scanned, 1);
@@ -657,42 +703,33 @@ mod tests {
 
     #[test]
     fn test_scale_factor_round_trip_cpm() {
-        // Verify the math: raw = cpm_val * scale_factor recovers original count.
-        // N=100M, 1 read in a 10 bp bin → CPM = 1e6/100M = 0.01
         let cpm_val: f64 = 0.01;
-        let scale = 1.0 / cpm_val; // = 100.0 = N/1e6
-        let raw = cpm_val * scale;
-        assert!((raw - 1.0).abs() < 1e-10); // recovers exactly 1 read
+        let scale = 1.0 / cpm_val;
+        assert!((cpm_val * scale - 1.0).abs() < 1e-10);
     }
 
     #[test]
     fn test_scale_factor_round_trip_rpkm() {
-        // N=10M, 1 read in a 10 bp bin → RPKM = 1e9/(N*bin) = 1e9/(10M*10) = 10.0
         let rpkm_val: f64 = 10.0;
-        let scale = 1.0 / rpkm_val; // = 0.1 = N*bin/1e9
-        // raw_read_density = rpkm_val * scale = 1.0  (1 read per bin)
-        let raw = rpkm_val * scale;
-        assert!((raw - 1.0).abs() < 1e-10);
+        let scale = 1.0 / rpkm_val;
+        assert!((rpkm_val * scale - 1.0).abs() < 1e-10);
     }
 
     #[test]
     fn test_error_on_empty_bigwig() {
-        // BigWig writer refuses an empty interval list → make_bigwig itself errors.
-        // infer_scale_factor would also error ("no non-zero values") if given such a file.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("empty.bw");
         let mut chroms = HashMap::new();
         chroms.insert("chr5".to_string(), 1000u32);
         let result = make_bigwig(&path, chroms, vec![]);
-        assert!(result.is_err(), "bigtools rejects empty interval list");
+        assert!(result.is_err());
     }
 
     #[test]
     fn test_to_raw_cpm() -> anyhow::Result<()> {
-        // N=100M, CPM: 1 read → 0.01. to_raw(0.01) should give 1.0.
         let dir = tempfile::tempdir()?;
         let path = make_two_chrom_bigwig(&dir, 0.01, 0.02, 10)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
         assert!((r.to_raw(0.01) - 1.0).abs() < 1e-6);
         Ok(())
     }
@@ -701,13 +738,222 @@ mod tests {
     fn test_json_serialization() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let path = make_two_chrom_bigwig(&dir, 0.01, 0.02, 10)?;
-        let r = infer_scale_factor(&path)?;
+        let r = infer_scale_factor(&path, &default_config())?;
         let json = serde_json::to_string(&r)?;
-        // Sanity: parses back and key fields are present
         let v: serde_json::Value = serde_json::from_str(&json)?;
         assert_eq!(v["norm_method"], "Cpm");
         assert!(v["scale_factor"].is_number());
         assert!(v["second_min_val"].is_number());
+        // warnings serialise as an empty array when all flags are false
+        assert!(v["warnings"].is_array());
+        assert_eq!(v["warnings"].as_array().unwrap().len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_warnings_serialize_as_messages() -> anyhow::Result<()> {
+        // Pseudocount case produces a non-empty warnings array.
+        let dir = tempfile::tempdir()?;
+        let path = make_two_chrom_bigwig(&dir, 0.0625, 0.1875, 10)?;
+        let r = infer_scale_factor(&path, &default_config())?;
+        let json = serde_json::to_string(&r)?;
+        let v: serde_json::Value = serde_json::from_str(&json)?;
+        let warnings = v["warnings"].as_array().unwrap();
+        assert!(!warnings.is_empty(), "pseudocount warning should appear");
+        assert!(
+            warnings[0]
+                .as_str()
+                .unwrap()
+                .starts_with("pseudocount_detected"),
+            "warning message should be a readable string"
+        );
+        Ok(())
+    }
+
+    // ─── heuristic correctness tests ─────────────────────────────────────────
+
+    /// Build a chromosome where the minimum appears after N leading intervals
+    /// of a higher value.  Used to probe the early-exit heuristic.
+    ///
+    /// Layout (bin_size=10, all on chr5):
+    ///   [0, 10)          → leading_val   (repeated `leading_n` times)
+    ///   [leading_n*10, …) → true_min     (one bin)
+    fn make_late_minimum_bigwig(
+        dir: &tempfile::TempDir,
+        leading_n: u32,
+        leading_val: f32,
+        true_min: f32,
+        bin_size: u32,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        let path = dir.path().join("late_min.bw");
+        let total_bins = leading_n + 1;
+        let chrom_len = total_bins * bin_size;
+        let mut chroms = HashMap::new();
+        // Two chromosomes so the cross-chrom confidence logic can fire.
+        chroms.insert("chr5".to_string(), chrom_len);
+        chroms.insert("chr7".to_string(), chrom_len);
+
+        let mut intervals: Vec<(String, u32, u32, f32)> = Vec::new();
+        for chrom in &["chr5", "chr7"] {
+            for i in 0..leading_n {
+                intervals.push((
+                    chrom.to_string(),
+                    i * bin_size,
+                    (i + 1) * bin_size,
+                    leading_val,
+                ));
+            }
+            // true minimum is the very last bin
+            intervals.push((
+                chrom.to_string(),
+                leading_n * bin_size,
+                (leading_n + 1) * bin_size,
+                true_min,
+            ));
+        }
+        make_bigwig(&path, chroms, intervals)?;
+        Ok(path)
+    }
+
+    /// The heuristic can miss a minimum that appears only after both a stable streak
+    /// AND a second distinct value have been seen.  Concrete failure pattern:
+    ///   [3.0]*A  [2.0]*(streak+5)  [1.0]*1
+    /// After A intervals of 3.0 the streak counter is A (min2 still MAX → no break).
+    /// The first 2.0 resets the streak; after streak+5 more 2.0s both conditions are
+    /// satisfied and we break before seeing 1.0.
+    #[test]
+    fn test_heuristic_misses_late_minimum() -> anyhow::Result<()> {
+        let streak: u32 = 8;
+        let config = InferScaleConfig {
+            min_stable_streak: streak,
+            max_starts: 512,
+        };
+        let full = full_scan_config();
+
+        // Layout per chromosome: [3.0]*5, [2.0]*(streak+5), [1.0]*1
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("late.bw");
+        let bin: u32 = 10;
+        let a: u32 = 5;
+        let b: u32 = streak + 5;
+        let chrom_len = (a + b + 1) * bin;
+        let mut chroms = HashMap::new();
+        chroms.insert("chr5".to_string(), chrom_len);
+        chroms.insert("chr7".to_string(), chrom_len);
+
+        let mut intervals: Vec<(String, u32, u32, f32)> = Vec::new();
+        for chrom in &["chr5", "chr7"] {
+            for i in 0..a {
+                intervals.push((chrom.to_string(), i * bin, (i + 1) * bin, 3.0));
+            }
+            for i in a..(a + b) {
+                intervals.push((chrom.to_string(), i * bin, (i + 1) * bin, 2.0));
+            }
+            intervals.push((chrom.to_string(), (a + b) * bin, (a + b + 1) * bin, 1.0));
+        }
+        make_bigwig(&path, chroms, intervals)?;
+
+        let r_full = infer_scale_factor(&path, &full)?;
+        let r_heur = infer_scale_factor(&path, &config)?;
+
+        // Full scan finds the true minimum.
+        assert!(
+            (r_full.min_val - 1.0).abs() < 1e-6,
+            "full scan min_val should be 1.0, got {}",
+            r_full.min_val
+        );
+        // Heuristic with small streak misses the late minimum — documents the limitation.
+        assert!(
+            r_heur.min_val > 1.0 + 1e-6,
+            "heuristic with streak={streak} should miss the late minimum (got {}); \
+             increase min_stable_streak or use u32::MAX to disable",
+            r_heur.min_val
+        );
+        Ok(())
+    }
+
+    /// With a sufficiently large streak the heuristic matches the full scan.
+    /// This is the normal operating regime for real BigWig files where a single-read
+    /// bin is rare but not exclusively clustered at the chromosome end.
+    #[test]
+    fn test_heuristic_matches_full_scan_minimum_not_late() -> anyhow::Result<()> {
+        // Minimum is the FIRST bin; all subsequent bins are higher.
+        // Any streak ≥ 1 will find the correct minimum.
+        let dir = tempfile::tempdir()?;
+        let path = make_late_minimum_bigwig(&dir, 0, 2.0, 1.0, 10)?;
+        // With 0 leading intervals the "late_minimum" fixture places 1.0 first.
+        // Re-use the fixture but build a simpler version: min first, rest larger.
+        let path2 = dir.path().join("min_first.bw");
+        {
+            let mut chroms = HashMap::new();
+            chroms.insert("chr5".to_string(), 200u32);
+            chroms.insert("chr7".to_string(), 200u32);
+            let mut ivs: Vec<(String, u32, u32, f32)> = Vec::new();
+            for chrom in &["chr5", "chr7"] {
+                ivs.push((chrom.to_string(), 0, 10, 1.0_f32));
+                for i in 1..20u32 {
+                    ivs.push((chrom.to_string(), i * 10, (i + 1) * 10, 2.0));
+                }
+            }
+            make_bigwig(&path2, chroms, ivs)?;
+        }
+        let _ = path; // suppress warning
+
+        let r_full = infer_scale_factor(&path2, &full_scan_config())?;
+        let r_heur = infer_scale_factor(
+            &path2,
+            &InferScaleConfig {
+                min_stable_streak: 5,
+                ..Default::default()
+            },
+        )?;
+
+        assert!(
+            (r_full.min_val - r_heur.min_val).abs() < 1e-9,
+            "heuristic and full scan should agree when minimum is not late: full={} heur={}",
+            r_full.min_val,
+            r_heur.min_val
+        );
+        assert_eq!(r_full.norm_method, r_heur.norm_method);
+        Ok(())
+    }
+
+    /// Default streak (50 000) is robust against a minimum that appears at a moderate
+    /// position — e.g. 1 000 intervals in, far short of 50 000.
+    #[test]
+    fn test_default_streak_robust_for_typical_position() -> anyhow::Result<()> {
+        // Pattern: 1000 bins of 2.0, then 1 bin of 1.0, then 1000 bins of 2.0
+        // The minimum is at interval 1000, well within the 50k streak window.
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("mid_min.bw");
+        let bin: u32 = 10;
+        let n: u32 = 1_000;
+        let chrom_len = (2 * n + 1) * bin;
+        let mut chroms = HashMap::new();
+        chroms.insert("chr5".to_string(), chrom_len);
+        chroms.insert("chr7".to_string(), chrom_len);
+
+        let mut ivs: Vec<(String, u32, u32, f32)> = Vec::new();
+        for chrom in &["chr5", "chr7"] {
+            for i in 0..n {
+                ivs.push((chrom.to_string(), i * bin, (i + 1) * bin, 2.0));
+            }
+            ivs.push((chrom.to_string(), n * bin, (n + 1) * bin, 1.0));
+            for i in (n + 1)..(2 * n + 1) {
+                ivs.push((chrom.to_string(), i * bin, (i + 1) * bin, 2.0));
+            }
+        }
+        make_bigwig(&path, chroms, ivs)?;
+
+        let r_full = infer_scale_factor(&path, &full_scan_config())?;
+        let r_heur = infer_scale_factor(&path, &default_config())?;
+
+        assert!(
+            (r_full.min_val - r_heur.min_val).abs() < 1e-9,
+            "default streak should find the correct minimum: full={} heur={}",
+            r_full.min_val,
+            r_heur.min_val
+        );
         Ok(())
     }
 }

--- a/bamnado/src/bigwig_infer_scale.rs
+++ b/bamnado/src/bigwig_infer_scale.rs
@@ -1,10 +1,44 @@
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
+use rayon::prelude::*;
+use serde::Serialize;
 use std::collections::HashSet;
-use std::io::{Read, Seek};
+use std::fs::File;
+use std::io::{BufReader, Read, Seek};
 use std::path::Path;
 
+/// Read buffer per thread — large enough to amortise syscall overhead on whole-chromosome fetches.
+const BW_BUF_BYTES: usize = 2 << 20; // 2 MB
+
+fn open_bw(path: &Path) -> Result<bigtools::BigWigRead<BufReader<File>>> {
+    let file = File::open(path).with_context(|| format!("Cannot open {}", path.display()))?;
+    let buf = BufReader::with_capacity(BW_BUF_BYTES, file);
+    bigtools::BigWigRead::open(buf).map_err(|e| anyhow::anyhow!("BigWig open error: {e}"))
+}
+
+fn ser_f64_max_null<S>(v: &f64, s: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if *v == f64::MAX {
+        s.serialize_none()
+    } else {
+        s.serialize_some(v)
+    }
+}
+
+fn ser_f64_nan_null<S>(v: &f64, s: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if v.is_nan() {
+        s.serialize_none()
+    } else {
+        s.serialize_some(v)
+    }
+}
+
 /// Inferred normalisation method.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum NormMethod {
     Cpm,
     Rpkm,
@@ -25,7 +59,7 @@ impl std::fmt::Display for NormMethod {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Warnings {
     /// More than 2 distinct interval widths — variable bin sizes found.
     pub variable_bin_sizes: bool,
@@ -37,7 +71,7 @@ pub struct Warnings {
     pub min_from_small_chrom: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct InferScaleResult {
     /// Inferred normalisation method.
     pub norm_method: NormMethod,
@@ -49,9 +83,11 @@ pub struct InferScaleResult {
     pub bin_size: u32,
     /// Global minimum non-zero bin value.
     pub min_val: f64,
-    /// Second-smallest distinct non-zero bin value.
+    /// Second-smallest distinct non-zero bin value (null when only one distinct value seen).
+    #[serde(serialize_with = "ser_f64_max_null")]
     pub second_min_val: f64,
-    /// second_min / min (diagnostic ratio).
+    /// second_min / min (diagnostic ratio; null when second_min unknown).
+    #[serde(serialize_with = "ser_f64_nan_null")]
     pub ratio: f64,
     /// Estimated pseudocount (if detected).
     pub pseudocount: Option<f64>,
@@ -62,10 +98,35 @@ pub struct InferScaleResult {
     pub chroms_scanned: usize,
 }
 
+impl InferScaleResult {
+    /// Convert a normalised BigWig value back to raw read count per bin.
+    ///
+    /// raw = value × scale_factor
+    ///
+    /// Derivation:
+    ///   CPM:  value = reads / (N/1e6)       →  raw = value × (N/1e6)
+    ///   RPKM: value = reads / (N×bin/1e9)   →  raw = value × (N×bin/1e9)
+    ///   Both reduce to: raw = value × scale_factor
+    ///
+    /// When a pseudocount was detected the scale_factor already uses second_min
+    /// (the smallest bin with ≥1 real read) so raw counts remain integer-valued.
+    pub fn to_raw(&self, value: f64) -> f64 {
+        value * self.scale_factor
+    }
+}
+
 /// Infer scale factor and normalisation method from a BigWig file.
+///
+/// Chromosomes are scanned in three priority groups (mid-sized autosomes first,
+/// large chromosomes second, small/unplaced last).  Each group is processed in
+/// parallel — every worker thread opens its own buffered reader.  Scanning stops
+/// as soon as the minimum value has been confirmed on ≥2 chromosomes and the
+/// second_min/min ratio is near an integer.
 pub fn infer_scale_factor(bw_path: &Path) -> Result<InferScaleResult> {
-    let mut reader = bigtools::BigWigRead::open_file(bw_path)?;
-    let chrom_info: Vec<bigtools::ChromInfo> = reader.chroms().to_owned();
+    let chrom_info: Vec<bigtools::ChromInfo> = {
+        let reader = open_bw(bw_path)?;
+        reader.chroms().to_owned()
+    };
 
     if chrom_info.is_empty() {
         bail!("BigWig file has no chromosomes");
@@ -73,9 +134,13 @@ pub fn infer_scale_factor(bw_path: &Path) -> Result<InferScaleResult> {
 
     let genome_size: u64 = chrom_info.iter().map(|c| c.length as u64).sum();
 
-    // Sort: mid-sized autosomes first, large deferred, small/unplaced last.
-    let mut sorted_chroms = chrom_info.clone();
-    sorted_chroms.sort_by_key(|c| chrom_priority(&c.name, c.length, genome_size));
+    // Partition into three priority groups — mid-sized autosomes first because
+    // they are the most likely to share the global minimum and confirm confidence
+    // quickly, while being small enough to scan fast.
+    let mut groups: [Vec<bigtools::ChromInfo>; 3] = [vec![], vec![], vec![]];
+    for c in &chrom_info {
+        groups[chrom_priority(&c.name, c.length, genome_size) as usize].push(c.clone());
+    }
 
     let mut global_min = f64::MAX;
     let mut global_second_min = f64::MAX;
@@ -85,49 +150,68 @@ pub fn infer_scale_factor(bw_path: &Path) -> Result<InferScaleResult> {
     let mut confident = false;
     let mut min_chrom_name = String::new();
 
-    for chrom in &sorted_chroms {
-        let (cmin, c2min, cwidths) = scan_chrom(&mut reader, &chrom.name, chrom.length)?;
-        chroms_scanned += 1;
-        global_starts.extend(cwidths);
-
-        if cmin == f64::MAX {
+    'outer: for group in &groups {
+        if group.is_empty() || confident {
             continue;
         }
 
-        const EPS: f64 = 1e-9;
+        // All chromosomes in this priority group are scanned in parallel.
+        // Each closure opens its own BigWigRead so there is no shared I/O state.
+        type ChromScan = Result<(String, f64, f64, HashSet<u32>)>;
+        let scan_results: Vec<ChromScan> = group
+            .par_iter()
+            .map(|chrom| {
+                let mut r = open_bw(bw_path)?;
+                let (cmin, c2min, cwidths) = scan_chrom(&mut r, &chrom.name, chrom.length)?;
+                Ok((chrom.name.clone(), cmin, c2min, cwidths))
+            })
+            .collect();
 
-        if cmin < global_min - EPS {
-            let old_min = global_min;
-            let old_second = global_second_min;
-            // Candidates for new second_min: old global_min, old second_min, this chrom's second_min.
-            global_second_min = [old_min, old_second, c2min]
-                .iter()
-                .copied()
-                .filter(|&v| v > cmin + EPS)
-                .fold(f64::MAX, f64::min);
-            global_min = cmin;
-            min_chrom_name = chrom.name.clone();
-            min_confirmations = 1;
-        } else if (cmin - global_min).abs() < EPS {
-            min_confirmations += 1;
-            if c2min < global_second_min - EPS {
-                global_second_min = c2min;
-            }
-        } else {
-            // cmin > global_min: update second_min only.
-            if cmin < global_second_min - EPS {
-                global_second_min = cmin;
-            }
-            if c2min > global_min + EPS && c2min < global_second_min - EPS {
-                global_second_min = c2min;
-            }
-        }
+        // Merge results sequentially — order within a group doesn't matter for
+        // correctness; the priority ordering ensures the most informative group
+        // is processed first so confidence is reached with fewest total scans.
+        for res in scan_results {
+            let (chrom_name, cmin, c2min, cwidths) = res?;
+            chroms_scanned += 1;
+            global_starts.extend(cwidths);
 
-        if min_confirmations >= 2 && global_second_min < f64::MAX {
-            let ratio = global_second_min / global_min;
-            if (ratio - ratio.round()).abs() < 0.01 {
-                confident = true;
-                break;
+            if cmin == f64::MAX {
+                continue;
+            }
+
+            const EPS: f64 = 1e-9;
+
+            if cmin < global_min - EPS {
+                let old_min = global_min;
+                let old_second = global_second_min;
+                global_second_min = [old_min, old_second, c2min]
+                    .iter()
+                    .copied()
+                    .filter(|&v| v > cmin + EPS)
+                    .fold(f64::MAX, f64::min);
+                global_min = cmin;
+                min_chrom_name = chrom_name;
+                min_confirmations = 1;
+            } else if (cmin - global_min).abs() < EPS {
+                min_confirmations += 1;
+                if c2min < global_second_min - EPS {
+                    global_second_min = c2min;
+                }
+            } else {
+                if cmin < global_second_min - EPS {
+                    global_second_min = cmin;
+                }
+                if c2min > global_min + EPS && c2min < global_second_min - EPS {
+                    global_second_min = c2min;
+                }
+            }
+
+            if min_confirmations >= 2 && global_second_min < f64::MAX {
+                let ratio = global_second_min / global_min;
+                if (ratio - ratio.round()).abs() < 0.01 {
+                    confident = true;
+                    break 'outer;
+                }
             }
         }
     }
@@ -181,7 +265,7 @@ pub fn infer_scale_factor(bw_path: &Path) -> Result<InferScaleResult> {
         _ => n_cpm,
     };
 
-    let min_chrom_fraction = sorted_chroms
+    let min_chrom_fraction = chrom_info
         .iter()
         .find(|c| c.name == min_chrom_name)
         .map(|c| c.length as f64 / genome_size as f64)
@@ -601,5 +685,29 @@ mod tests {
         chroms.insert("chr5".to_string(), 1000u32);
         let result = make_bigwig(&path, chroms, vec![]);
         assert!(result.is_err(), "bigtools rejects empty interval list");
+    }
+
+    #[test]
+    fn test_to_raw_cpm() -> anyhow::Result<()> {
+        // N=100M, CPM: 1 read → 0.01. to_raw(0.01) should give 1.0.
+        let dir = tempfile::tempdir()?;
+        let path = make_two_chrom_bigwig(&dir, 0.01, 0.02, 10)?;
+        let r = infer_scale_factor(&path)?;
+        assert!((r.to_raw(0.01) - 1.0).abs() < 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_serialization() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = make_two_chrom_bigwig(&dir, 0.01, 0.02, 10)?;
+        let r = infer_scale_factor(&path)?;
+        let json = serde_json::to_string(&r)?;
+        // Sanity: parses back and key fields are present
+        let v: serde_json::Value = serde_json::from_str(&json)?;
+        assert_eq!(v["norm_method"], "Cpm");
+        assert!(v["scale_factor"].is_number());
+        assert!(v["second_min_val"].is_number());
+        Ok(())
     }
 }

--- a/bamnado/src/main.rs
+++ b/bamnado/src/main.rs
@@ -398,6 +398,20 @@ enum Commands {
         /// Output format.
         #[arg(long, value_enum, default_value = "table")]
         format: InferScaleFormat,
+
+        /// Write output to FILE instead of stdout.
+        #[arg(short, long, value_name = "FILE")]
+        output: Option<PathBuf>,
+
+        /// Stop scanning a chromosome after N consecutive intervals with no new minimum.
+        /// Set to 0 to disable early exit (full scan). Default 50000.
+        #[arg(long, value_name = "N", default_value = "50000")]
+        min_stable_streak: u32,
+
+        /// Maximum interval start positions collected for bin-size (GCD) inference.
+        /// Default 512 — GCD stabilises within the first few entries.
+        #[arg(long, value_name = "N", default_value = "512")]
+        max_starts: usize,
     },
 }
 
@@ -1018,10 +1032,26 @@ fn main() -> Result<()> {
                 }
             }
         }
-        Commands::InferScale { bigwig, format } => {
-            let result = bamnado::bigwig_infer_scale::infer_scale_factor(bigwig)
+        Commands::InferScale {
+            bigwig,
+            format,
+            output,
+            min_stable_streak,
+            max_starts,
+        } => {
+            let config = bamnado::bigwig_infer_scale::InferScaleConfig {
+                min_stable_streak: if *min_stable_streak == 0 {
+                    u32::MAX
+                } else {
+                    *min_stable_streak
+                },
+                max_starts: *max_starts,
+            };
+            let result = bamnado::bigwig_infer_scale::infer_scale_factor(bigwig, &config)
                 .context("Failed to infer scale factor from BigWig")?;
 
+            // Build output string then write to file or stdout.
+            let mut buf = String::new();
             match format {
                 InferScaleFormat::Table => {
                     let mut table = Table::new();
@@ -1075,65 +1105,73 @@ fn main() -> Result<()> {
                         ]);
                     }
 
-                    println!("{table}");
+                    use std::fmt::Write as _;
+                    writeln!(buf, "{table}").unwrap();
 
-                    let mut warnings: Vec<&str> = Vec::new();
-                    if result.warnings.pseudocount_detected {
-                        warnings
-                            .push("pseudocount detected — scale factor corrected using second_min");
-                    }
-                    if result.warnings.smoothing_detected {
-                        warnings.push("ratio is non-integer — smoothing may have been applied; recovery is approximate");
-                    }
-                    if result.warnings.variable_bin_sizes {
-                        warnings.push("variable bin sizes detected — RPKM reversal unreliable");
-                    }
-                    if result.warnings.min_from_small_chrom {
-                        warnings.push(
-                            "minimum value came from a small chromosome — may be artefactual",
-                        );
-                    }
-                    for w in warnings {
+                    // Warnings always go to stderr regardless of --output.
+                    for w in result.warnings.messages() {
                         eprintln!("Warning: {w}");
                     }
                 }
                 InferScaleFormat::Tsv => {
-                    println!("field\tvalue");
-                    println!("normalisation\t{}", result.norm_method);
-                    println!("scale_factor\t{:.6e}", result.scale_factor);
-                    println!("to_raw\tvalue × {:.6e}", result.scale_factor);
-                    println!("library_size\t{:.0}", result.library_size);
-                    println!("bin_size\t{}", result.bin_size);
-                    println!("min_val\t{:.6e}", result.min_val);
-                    println!(
+                    use std::fmt::Write as _;
+                    writeln!(buf, "field\tvalue").unwrap();
+                    writeln!(buf, "normalisation\t{}", result.norm_method).unwrap();
+                    writeln!(buf, "scale_factor\t{:.6e}", result.scale_factor).unwrap();
+                    writeln!(buf, "to_raw\tvalue × {:.6e}", result.scale_factor).unwrap();
+                    writeln!(buf, "library_size\t{:.0}", result.library_size).unwrap();
+                    writeln!(buf, "bin_size\t{}", result.bin_size).unwrap();
+                    writeln!(buf, "min_val\t{:.6e}", result.min_val).unwrap();
+                    writeln!(
+                        buf,
                         "second_min_val\t{}",
                         if result.second_min_val < f64::MAX {
                             format!("{:.6e}", result.second_min_val)
                         } else {
                             "n/a".to_string()
                         }
-                    );
-                    println!(
+                    )
+                    .unwrap();
+                    writeln!(
+                        buf,
                         "ratio\t{}",
                         if result.ratio.is_nan() {
                             "n/a".to_string()
                         } else {
                             format!("{:.4}", result.ratio)
                         }
-                    );
-                    println!(
+                    )
+                    .unwrap();
+                    writeln!(
+                        buf,
                         "pseudocount\t{}",
                         result
                             .pseudocount
                             .map(|p| format!("{:.4}", p))
                             .unwrap_or_else(|| "none".to_string())
-                    );
-                    println!("confident\t{}", if result.confident { "yes" } else { "no" });
-                    println!("chroms_scanned\t{}", result.chroms_scanned);
+                    )
+                    .unwrap();
+                    writeln!(
+                        buf,
+                        "confident\t{}",
+                        if result.confident { "yes" } else { "no" }
+                    )
+                    .unwrap();
+                    writeln!(buf, "chroms_scanned\t{}", result.chroms_scanned).unwrap();
+                    for w in result.warnings.messages() {
+                        writeln!(buf, "warning\t{w}").unwrap();
+                    }
                 }
                 InferScaleFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&result)?);
+                    buf = serde_json::to_string_pretty(&result)?;
+                    buf.push('\n');
                 }
+            }
+
+            match output {
+                Some(path) => std::fs::write(path, &buf)
+                    .with_context(|| format!("Cannot write to {}", path.display()))?,
+                None => print!("{buf}"),
             }
         }
     }

--- a/bamnado/src/main.rs
+++ b/bamnado/src/main.rs
@@ -405,6 +405,7 @@ enum Commands {
 enum InferScaleFormat {
     Table,
     Tsv,
+    Json,
 }
 
 // Helper functions to reduce code duplication
@@ -1033,6 +1034,7 @@ fn main() -> Result<()> {
                     let rows: Vec<(&str, String)> = vec![
                         ("normalisation", result.norm_method.to_string()),
                         ("scale_factor", format!("{:.6e}", result.scale_factor)),
+                        ("to_raw", format!("value × {:.6e}", result.scale_factor)),
                         ("library_size", format!("{:.0}", result.library_size)),
                         ("bin_size", format!("{} bp", result.bin_size)),
                         ("min_val", format!("{:.6e}", result.min_val)),
@@ -1099,6 +1101,7 @@ fn main() -> Result<()> {
                     println!("field\tvalue");
                     println!("normalisation\t{}", result.norm_method);
                     println!("scale_factor\t{:.6e}", result.scale_factor);
+                    println!("to_raw\tvalue × {:.6e}", result.scale_factor);
                     println!("library_size\t{:.0}", result.library_size);
                     println!("bin_size\t{}", result.bin_size);
                     println!("min_val\t{:.6e}", result.min_val);
@@ -1127,6 +1130,9 @@ fn main() -> Result<()> {
                     );
                     println!("confident\t{}", if result.confident { "yes" } else { "no" });
                     println!("chroms_scanned\t{}", result.chroms_scanned);
+                }
+                InferScaleFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&result)?);
                 }
             }
         }


### PR DESCRIPTION
This pull request enhances the `InferScale` command in the `bamnado` CLI tool by adding new output options, configurability, and usability improvements. The changes introduce support for JSON output, allow writing results to a file, and provide new parameters for controlling the inference process. Output formatting and warning handling have also been improved for clarity and flexibility.

**InferScale command improvements:**

* Added support for writing output to a file via the new `--output`/`-o` argument, instead of always printing to stdout. [[1]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cR401-R422) [[2]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cL1076-R1175)
* Introduced new arguments: `--min-stable-streak` to control early exit after a number of stable intervals, and `--max-starts` to set the maximum number of interval start positions used for bin-size inference. [[1]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cR401-R422) [[2]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cL1020-R1054)
* Added a `json` output format in addition to the existing `table` and `tsv` formats. [[1]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cR401-R422) [[2]](diffhunk://#diff-af45cb6785a7d57f35ee64d6802827cf61ba2dff7a2f8dcd75b8955ce48e179cL1076-R1175)

**Output formatting and warnings:**

* Refactored output handling to build the output as a string buffer, which is then written to either a file or stdout, depending on user input.
* Improved warning messages: warnings are now consistently written to stderr (for table) or included as lines in the output (for tsv), and are generated via a new `messages()` method.

**Documentation update:**

* Updated `CLAUDE.md` with notes on building the Rust library and CLI without Python bindings, clarifying the use of `cargo build -p bamnado` and `maturin` for different build scenarios.