### PR TITLE
fix: resolve 23 correctness and safety bugs across core modules

### DIFF
--- a/bamnado-python/src/lib.rs
+++ b/bamnado-python/src/lib.rs
@@ -77,7 +77,7 @@ mod _bamnado {
         #[new]
         #[pyo3(signature = (
             min_mapq=0,
-            proper_pair=true,
+            proper_pair=false,
             min_length=0,
             max_length=1000,
             strand="both",
@@ -293,7 +293,7 @@ mod _bamnado {
         for interval in signal {
             let start = interval.start;
             let end = interval.stop;
-            let value = interval.val as f32;
+            let value = interval.val as f32 * scale_factor;
             array.slice_mut(s![start..end]).fill(value);
         }
 

--- a/bamnado/src/bam_utils.rs
+++ b/bamnado/src/bam_utils.rs
@@ -134,13 +134,18 @@ impl CellBarcodes {
             .finish()?;
         let mut barcodes = HashSet::default();
 
-        for barcode in df.column("barcode").unwrap().str().unwrap() {
-            let barcode = barcode.unwrap().to_string();
+        let col = df
+            .column("barcode")
+            .context("Missing 'barcode' column in barcode CSV")?;
+        for barcode in col.str().context("'barcode' column is not string type")? {
+            let barcode = barcode
+                .ok_or_else(|| anyhow::anyhow!("Null value in 'barcode' column"))?
+                .to_string();
             barcodes.insert(barcode);
         }
 
-        println!("Number of barcodes: {}", barcodes.len());
-        println!(
+        log::info!("Loaded {} barcodes", barcodes.len());
+        log::debug!(
             "First 10 barcodes: {:?}",
             barcodes.iter().take(10).collect::<Vec<_>>()
         );
@@ -215,57 +220,6 @@ struct ChromosomeStats {
     unmapped: u64,
 }
 
-/// Reads the header of a BAM file.
-///
-/// If the `noodles` crate fails to read the header, it falls back to `samtools`.
-/// This is useful for handling BAM files with slightly non-standard headers (e.g., from CellRanger).
-pub fn bam_header(file_path: PathBuf) -> Result<sam::Header> {
-    // Read the header of a BAM file
-    // If the noodles crate fails to read the header, we fall back to samtools
-    // This is a bit of a hack but it works for now
-    // The noodles crate is more strict about the header format than samtools
-
-    // Check that the file exists
-    if !file_path.exists() {
-        return Err(anyhow::Error::from(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("File not found: {}", file_path.display()),
-        )));
-    };
-
-    let mut reader = bam::io::indexed_reader::Builder::default()
-        .build_from_path(file_path.clone())
-        .expect("Failed to open file");
-
-    let header = match reader.read_header() {
-        std::result::Result::Ok(header) => header,
-        Err(e) => {
-            debug!("Failed to read header using noodels falling back to samtools: {e}");
-
-            let header_samtools = std::process::Command::new("samtools")
-                .arg("view")
-                .arg("-H")
-                .arg(file_path.clone())
-                .output()
-                .expect("Failed to run samtools")
-                .stdout;
-
-            let header_str =
-                String::from_utf8(header_samtools).expect("Failed to convert header to string");
-
-            // Slight hack here for CellRanger BAM files that are missing the version info
-            let header_string =
-                header_str.replace("@HD\tSO:coordinate\n", "@HD\tVN:1.6\tSO:coordinate\n");
-            let header_str = header_string.as_bytes();
-            let mut reader = sam::io::Reader::new(header_str);
-            reader
-                .read_header()
-                .expect("Failed to read header with samtools")
-        }
-    };
-    Ok(header)
-}
-
 /// Stores statistics and metadata about a BAM file.
 pub struct BamStats {
     // BAM file stats
@@ -298,7 +252,7 @@ impl BamStats {
     /// This reads the header and index to calculate statistics.
     pub fn new(file_path: PathBuf) -> Result<Self> {
         // Read the header of the BAM file
-        let header = bam_header(file_path.clone())?;
+        let header = get_bam_header(file_path.clone())?;
 
         // Get the contigs from the header
         let contigs = header
@@ -377,6 +331,9 @@ impl BamStats {
 
         let stats = &self.chrom_stats;
         let genome_length = stats.values().map(|x| x.length).sum::<u64>();
+        if genome_length == 0 || self.n_mapped == 0 {
+            return Ok(bin_size);
+        }
         let max_reads_per_bp = self.n_mapped as f64 / genome_length as f64;
         let genome_chunk_length = 5e6_f64.min(2e6 / (max_reads_per_bp));
 
@@ -588,8 +545,8 @@ pub fn regions_to_lapper(regions: Vec<Region>) -> Result<HashMap<String, Lapper<
         };
 
         let end = match end {
-            Bound::Included(end) => end,
-            Bound::Excluded(end) => end - 1,
+            Bound::Included(end) => end + 1, // Lapper is half-open [start, stop)
+            Bound::Excluded(end) => end,
             _ => 0,
         };
 
@@ -685,23 +642,23 @@ where
 
     let mut reader = bam::io::indexed_reader::Builder::default()
         .build_from_path(file_path)
-        .expect("Failed to open file");
+        .context("Failed to open BAM file")?;
 
     let header = match reader.read_header() {
         std::result::Result::Ok(header) => header,
         Err(e) => {
-            debug!("Failed to read header using noodels falling back to samtools: {e}");
+            debug!("Failed to read header using noodles, falling back to samtools: {e}");
 
             let header_samtools = std::process::Command::new("samtools")
                 .arg("view")
                 .arg("-H")
                 .arg(file_path)
                 .output()
-                .expect("Failed to run samtools")
+                .context("Failed to run samtools")?
                 .stdout;
 
-            let header_str =
-                String::from_utf8(header_samtools).expect("Failed to convert header to string");
+            let header_str = String::from_utf8(header_samtools)
+                .context("Failed to convert samtools header to UTF-8")?;
 
             // Slight hack here for CellRanger BAM files that are missing the version info
             let header_string =
@@ -710,7 +667,7 @@ where
             let mut reader = sam::io::Reader::new(header_str);
             reader
                 .read_header()
-                .expect("Failed to read header with samtools")
+                .context("Failed to parse samtools header")?
         }
     };
     Ok(header)

--- a/bamnado/src/coverage_analysis.rs
+++ b/bamnado/src/coverage_analysis.rs
@@ -38,7 +38,7 @@ use rust_lapper::Lapper;
 fn is_scaffold(name: &str) -> bool {
     static SCAFFOLD_REGEX: OnceLock<Regex> = OnceLock::new();
     SCAFFOLD_REGEX
-        .get_or_init(|| Regex::new("(chrUn.*|.*alt|.*random)").unwrap())
+        .get_or_init(|| Regex::new(r"^chrUn|_alt$|_random$").unwrap())
         .is_match(name)
 }
 
@@ -105,28 +105,32 @@ fn collapse_equal_bins(df: DataFrame, score_columns: Option<Vec<PlSmallStr>>) ->
         same_scores.push(same_score);
     }
 
-    // Sum the boolean columns to get a single boolean column
-    let same_chrom_and_score = same_chrom
-        & same_scores
-            .iter()
-            .fold(same_scores[0].clone(), |acc, x| acc & x.clone());
+    // AND all per-score boolean columns together (handles empty score_columns)
+    let combined_scores = same_scores.into_iter().reduce(|a, b| a & b);
+    let same_chrom_and_score = match combined_scores {
+        Some(scores) => same_chrom & scores,
+        None => same_chrom,
+    };
 
-    // Compute a cumulative sum to define groups of identical rows.
-    let group = cum_sum(&same_chrom_and_score.into_series(), false)?
+    // Compute groups: increment whenever the value CHANGES.
+    // Fill nulls (first row has no previous → treat as "different") before negating.
+    let same_no_null = same_chrom_and_score
+        .into_series()
+        .fill_null(FillNullStrategy::Zero)? // null → false
+        .bool()?
+        .clone();
+    let group = cum_sum(&(!same_no_null).into_series(), false)?
         .with_name("groups".into())
         .into_column();
 
+    let mut agg_exprs = vec![col("chrom").first(), col("start").min(), col("end").max()];
+    agg_exprs.extend(score_columns.iter().map(|c| col(c.as_str()).first()));
     let df = df
         .with_column(group)?
         .clone()
         .lazy()
         .group_by(["groups"])
-        .agg(&[
-            col("chrom").first(),
-            col("start").min(),
-            col("end").max(),
-            col("score").sum(),
-        ])
+        .agg(&agg_exprs)
         .collect()?;
 
     let collapsed_rows = df.height();
@@ -422,17 +426,23 @@ impl BamPileup {
                 }
                 Ok(bin_counts)
             })
-            // Combine the results from parallel threads.
-            .fold(Vec::new, |mut acc, result: Result<Vec<Iv>>| {
-                if let Ok(mut intervals) = result {
-                    acc.append(&mut intervals);
-                }
-                acc
-            })
-            .reduce(Vec::new, |mut acc, mut vec| {
-                acc.append(&mut vec);
-                acc
-            });
+            // Combine the results from parallel threads, propagating any errors.
+            .fold(
+                || Ok(Vec::new()),
+                |acc: Result<Vec<Iv>>, result: Result<Vec<Iv>>| {
+                    let mut acc = acc?;
+                    acc.append(&mut result?);
+                    Ok(acc)
+                },
+            )
+            .reduce(
+                || Ok(Vec::new()),
+                |acc: Result<Vec<Iv>>, b: Result<Vec<Iv>>| {
+                    let mut acc = acc?;
+                    acc.append(&mut b?);
+                    Ok(acc)
+                },
+            )?;
 
         let interval_count = pileup.len();
         let total_coverage: u64 = pileup.iter().map(|iv| (iv.stop - iv.start) as u64).sum();
@@ -550,22 +560,26 @@ impl BamPileup {
 
                 Ok((region.name().to_owned().to_string(), bin_counts))
             })
-            // Combine the results from parallel threads.
+            // Combine the results from parallel threads, propagating any errors.
             .fold(
-                HashMap::<String, Vec<Iv>>::default,
-                |mut acc, result: Result<(String, Vec<Iv>)>| {
-                    if let Ok((chrom, intervals)) = result {
-                        acc.entry(chrom).or_default().extend(intervals);
-                    }
-                    acc
+                || Ok(HashMap::<String, Vec<Iv>>::default()),
+                |acc: Result<HashMap<String, Vec<Iv>>>, result: Result<(String, Vec<Iv>)>| {
+                    let mut acc = acc?;
+                    let (chrom, intervals) = result?;
+                    acc.entry(chrom).or_default().extend(intervals);
+                    Ok(acc)
                 },
             )
-            .reduce(HashMap::default, |mut acc, map| {
-                for (key, mut value) in map {
-                    acc.entry(key).or_default().append(&mut value);
-                }
-                acc
-            });
+            .reduce(
+                || Ok(HashMap::default()),
+                |acc: Result<HashMap<String, Vec<Iv>>>, b: Result<HashMap<String, Vec<Iv>>>| {
+                    let mut acc = acc?;
+                    for (key, mut value) in b? {
+                        acc.entry(key).or_default().append(&mut value);
+                    }
+                    Ok(acc)
+                },
+            )?;
 
         let n_chromosomes = pileup.len();
         let total_intervals: usize = pileup.values().map(|ivs| ivs.len()).sum();
@@ -691,10 +705,8 @@ impl BamPileup {
             if self.ignore_scaffold_chromosomes && is_scaffold(&name) {
                 continue;
             }
-            let len_u32 = u32::try_from(len).context(format!(
-                "Chromosome {} length {} exceeds u32::MAX",
-                name, len
-            ))?;
+            let len_u32 = u32::try_from(len)
+                .with_context(|| format!("Chromosome {name} length {len} exceeds u32::MAX"))?;
             chrom_sizes_vec.push((name, len_u32));
         }
         let chrom_sizes: std::collections::HashMap<String, u32> =
@@ -824,6 +836,10 @@ impl MultiBamPileup {
     }
 
     fn _validate_bam_pileups(&self) -> Result<()> {
+        if self.bam_pileups.is_empty() {
+            anyhow::bail!("At least one BAM pileup is required");
+        }
+
         // Check that all BAM pileups have the same bin size.
         let bin_sizes: Vec<u64> = self.bam_pileups.iter().map(|p| p.bin_size).collect();
         if bin_sizes.iter().all(|&x| x == bin_sizes[0]) {
@@ -854,7 +870,7 @@ impl MultiBamPileup {
         let names: Vec<PlSmallStr> = self
             .bam_pileups
             .iter()
-            .map(|p| p.file_path.clone().to_str().unwrap().into())
+            .map(|p| p.file_path.to_string_lossy().as_ref().into())
             .collect::<Vec<_>>();
 
         for pileup in &self.bam_pileups {
@@ -999,10 +1015,11 @@ mod tests {
         // Should collapse adjacent bins with same scores
         assert!(result.height() < 4);
 
-        // Verify the collapsed bins have correct aggregated values
+        // Each group keeps the first (representative) score value, not the sum.
+        // Group [score=10, score=10] → score=10; group [score=20, score=20] → score=20.
         let score_col = result.column("score").unwrap();
         let score = score_col.sum_reduce().expect("Failed to sum scores");
-        assert_eq!(score.as_any_value().try_extract::<u32>().unwrap(), 60);
+        assert_eq!(score.as_any_value().try_extract::<u32>().unwrap(), 30);
     }
 
     #[test]

--- a/bamnado/src/genomic_intervals.rs
+++ b/bamnado/src/genomic_intervals.rs
@@ -31,13 +31,14 @@ where
     cigar.iter().try_fold(0, |acc, op| {
         let op = op.context("Failed to parse CIGAR operation")?;
         match op.kind() {
+            // Reference-consuming operations
             Kind::Match
-            | Kind::Insertion
+            | Kind::Deletion
+            | Kind::Skip
             | Kind::SequenceMatch
-            | Kind::Pad
             | Kind::SequenceMismatch => Ok(acc + op.len()),
-            Kind::Deletion | Kind::Skip => Ok(acc),
-            _ => Ok(acc), // Ignore other kinds like SoftClip, HardClip, etc.
+            // Query-only or padding — do not consume reference
+            _ => Ok(acc),
         }
     })
 }
@@ -45,7 +46,7 @@ where
 /// Represents coordinate shifts to be applied to reads.
 ///
 /// The shifts can be applied to the 5' and 3' ends of forward and reverse reads.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Shift {
     /// Shift for the 5' end of forward reads.
     pub five_prime: i32,
@@ -55,32 +56,17 @@ pub struct Shift {
     pub five_prime_reverse: i32,
     /// Shift for the 3' end of reverse reads.
     pub three_prime_reverse: i32,
-    index: usize,
 }
 
-impl Iterator for Shift {
-    type Item = i32;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.index {
-            0 => {
-                self.index += 1;
-                Some(self.five_prime)
-            }
-            1 => {
-                self.index += 1;
-                Some(self.three_prime)
-            }
-            2 => {
-                self.index += 1;
-                Some(self.five_prime_reverse)
-            }
-            3 => {
-                self.index += 1;
-                Some(self.three_prime_reverse)
-            }
-            _ => None,
-        }
+impl Shift {
+    /// Returns all four shift values as an array.
+    pub fn values(self) -> [i32; 4] {
+        [
+            self.five_prime,
+            self.three_prime,
+            self.five_prime_reverse,
+            self.three_prime_reverse,
+        ]
     }
 }
 
@@ -103,7 +89,6 @@ impl FromStr for Shift {
             three_prime,
             five_prime_reverse,
             three_prime_reverse,
-            index: 0,
         })
     }
 }
@@ -115,10 +100,10 @@ impl From<[i32; 4]> for Shift {
             three_prime: shift[1],
             five_prime_reverse: shift[2],
             three_prime_reverse: shift[3],
-            index: 0,
         }
     }
 }
+
 impl From<[usize; 4]> for Shift {
     fn from(shift: [usize; 4]) -> Self {
         Self {
@@ -126,23 +111,25 @@ impl From<[usize; 4]> for Shift {
             three_prime: shift[1] as i32,
             five_prime_reverse: shift[2] as i32,
             three_prime_reverse: shift[3] as i32,
-            index: 0,
         }
     }
 }
 
-impl From<Vec<i32>> for Shift {
-    fn from(shift: Vec<i32>) -> Self {
-        if shift.len() != 4 {
-            panic!("Shift vector must have exactly 4 elements");
-        }
-        Self {
+impl TryFrom<Vec<i32>> for Shift {
+    type Error = anyhow::Error;
+
+    fn try_from(shift: Vec<i32>) -> Result<Self> {
+        anyhow::ensure!(
+            shift.len() == 4,
+            "Shift vector must have exactly 4 elements, got {}",
+            shift.len()
+        );
+        Ok(Self {
             five_prime: shift[0],
             three_prime: shift[1],
             five_prime_reverse: shift[2],
             three_prime_reverse: shift[3],
-            index: 0,
-        }
+        })
     }
 }
 
@@ -375,7 +362,7 @@ impl<'a> IntervalMaker<'a> {
                     self.coords_read()?
                 };
 
-                let (start, end, dtlen) = if self.shift.into_iter().any(|x| x != 0) {
+                let (start, end, dtlen) = if self.shift.values().iter().any(|&x| x != 0) {
                     self.coords_shifted(start, end, dtlen).ok()?
                 } else {
                     (start, end, dtlen as i32)

--- a/bamnado/src/read_filter.rs
+++ b/bamnado/src/read_filter.rs
@@ -530,7 +530,7 @@ impl BamReadFilter {
             }
         }
 
-        let header = header.expect("No header provided");
+        let header = header.ok_or_else(|| anyhow::anyhow!("No header provided"))?;
         let chrom_id = alignment
             .reference_sequence_id(header)
             .context("Failed to get reference sequence ID")??;
@@ -576,7 +576,15 @@ impl BamReadFilter {
         if let Some(read_group) = &self.read_group {
             let rg = noodles::sam::alignment::record::data::field::tag::Tag::READ_GROUP;
             let data = alignment.data();
-            let read_group_value = data.get(&rg).context("Failed to get read group")??;
+            let read_group_value = match data.get(&rg) {
+                None => {
+                    self.stats
+                        .n_not_in_read_group
+                        .fetch_add(1, Ordering::Relaxed);
+                    return Ok(false);
+                }
+                Some(v) => v?,
+            };
 
             match read_group_value {
                 Value::String(value) => {

--- a/bamnado/src/signal_normalization.rs
+++ b/bamnado/src/signal_normalization.rs
@@ -32,10 +32,9 @@ impl NormalizationMethod {
             "raw" => Ok(NormalizationMethod::Raw),
             "rpkm" => Ok(NormalizationMethod::RPKM),
             "cpm" => Ok(NormalizationMethod::CPM),
-            _ => {
-                warn!("Unknown normalization method: {s}. Defaulting to Raw");
-                Ok(NormalizationMethod::Raw)
-            }
+            _ => Err(anyhow::anyhow!(
+                "Unknown normalization method: '{s}'. Valid options: raw, cpm, rpkm"
+            )),
         }
     }
 
@@ -55,14 +54,20 @@ impl NormalizationMethod {
             Self::Raw => base,
 
             Self::CPM => {
-                // Counts Per Million: normalize by library size
+                if n_reads == 0 {
+                    warn!("n_reads is 0; CPM normalization undefined, returning 0.0");
+                    return 0.0;
+                }
                 base * (1_000_000.0 / n_reads as f64)
             }
 
             Self::RPKM => {
-                // Reads Per Kilobase per Million: normalize by both length and library size
+                if n_reads == 0 {
+                    warn!("n_reads is 0; RPKM normalization undefined, returning 0.0");
+                    return 0.0;
+                }
                 let reads_per_million = 1_000_000.0 / n_reads as f64;
-                let per_kilobase = 1_000.0 / bin_size as f64; // Convert bp to kb
+                let per_kilobase = 1_000.0 / bin_size as f64;
                 base * reads_per_million * per_kilobase
             }
         }


### PR DESCRIPTION
Critical:
- collapse_equal_bins: fix group boundary logic (null-fill before negation), use .first() not .sum() to avoid N× inflation, use dynamic score columns so MultiBamPileup (renamed cols) no longer panics at runtime
- pileup_chromosome / pileup_genome: propagate BAM I/O errors instead of silently swallowing them in fold/reduce
- get_signal_for_chromosome: apply scale_factor when filling output array

High:
- alignment_span: fix inverted CIGAR logic — Deletion/Skip now consume reference; Insertion/Pad excluded
- Shift: remove index field (polluted PartialEq/Hash); drop Iterator impl; add values() -> [i32; 4]; From<Vec<i32>> -> TryFrom returning Result
- header.expect("No header provided") -> ok_or_else()?  in is_valid
- scale_factor: guard n_reads==0 in CPM/RPKM to avoid infinity output
- RG-tag missing reads now increment n_not_in_read_group counter correctly
- MultiBamPileup::_validate_bam_pileups: bail on empty input

Medium:
- NormalizationMethod::from_str: return Err on unknown input instead of silently defaulting to Raw
- bam_header deleted; all callers routed to get_bam_header
- get_bam_header: replace four .expect() panics with .context()?
- CellBarcodes::from_csv: replace panicking unwraps with error propagation; replace println! with log::info!/log::debug!
- estimate_genome_chunk_length: guard genome_length==0 / n_mapped==0
- regions_to_lapper: fix off-by-one (Included → end+1, Excluded → end)
- is_scaffold regex anchored: r"^chrUn|_alt$|_random$"
- .context(format!(...)) -> .with_context(|| format!(...))
- MultiBamPileup file path: to_string_lossy() replaces to_str().unwrap()

Low:
- Python ReadFilter proper_pair default: true -> false to match CLI