### PR TITLE
Add bam-normalize CLI command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,12 @@ BamNado/
 │       ├── coverage_analysis.rs    # BamPileup — parallel pileup/coverage engine
 │       ├── read_filter.rs          # BamReadFilter — per-read filtering logic
 │       ├── genomic_intervals.rs    # IntervalMaker — BAM record → genomic interval
-│       ├── bam_utils.rs            # BamStats, helpers, Iv type alias
+│       ├── bam_utils.rs            # BamStats, helpers, Iv type alias, bin_intervals()
+│       ├── bin_counts.rs           # BinCounts, count_bins() — shared per-sample bin count matrix
+│       ├── normalization_factors.rs # TMM / csaw-background / CPM / median-of-ratios / spike-in scale factors
 │       └── signal_normalization.rs # Raw / CPM / RPKM normalisation
 ├── bamnado-python/   # PyO3 Python extension (cdylib)
-│   ├── src/lib.rs    # Python bindings — exposes get_signal_for_chromosome()
+│   ├── src/lib.rs    # Python bindings — exposes get_signal_for_chromosome(), compute_scale_factors()
 │   └── python/bamnado/__init__.py
 ├── Cargo.toml        # Workspace root
 └── pyproject.toml    # maturin build config for the Python package
@@ -27,10 +29,12 @@ BamNado/
 | Type | Location | Purpose |
 | ---- | -------- | ------- |
 | `BamPileup` | `coverage_analysis.rs` | Parallel per-chromosome coverage computation |
-| `BamReadFilter` | `read_filter.rs` | Multi-criterion read filter (strand, MAPQ, length, fragment length, blacklist, barcode…) |
+| `BamReadFilter` | `read_filter.rs` | Multi-criterion read filter (strand, MAPQ, length, fragment length, blacklist, barcode, duplicate/secondary/supplementary…) |
 | `IntervalMaker` | `genomic_intervals.rs` | Converts BAM records to `Iv` intervals (fragment or read mode, with optional shift/truncate) |
 | `Iv` | `bam_utils.rs` | `Interval<usize, u32>` from `rust-lapper` |
 | `Shift` / `Truncate` | `genomic_intervals.rs` | 5′/3′ coordinate adjustments (e.g. Tn5) |
+| `BinCounts` | `bin_counts.rs` | Shared sample × bin read-count matrix across one or more BAM files |
+| `NormFactorEstimator` | `normalization_factors.rs` | Pluggable between-sample scaling factor strategy (`Tmm`, `CsawBackground`, `Cpm`, `MedianOfRatios`); `SpikeIn` is handled separately via `spike_in_scale_factors()` since it reads the BAM index directly rather than a bin matrix |
 
 ## Python API
 
@@ -74,6 +78,7 @@ signal = get_signal_for_chromosome(
 | `bigwig-compare` | `compare-bigwigs` | Compare two BigWig files bin by bin |
 | `bigwig-aggregate` | `aggregate-bigwigs` | Aggregate multiple BigWig files into one track |
 | `bigwig-infer-scale` | `infer-scale` | Infer scaling factor and library size from a normalised BigWig |
+| `bam-normalize` | `norm-factors` | Compute between-sample scaling factors (TMM / csaw-background / CPM / median-of-ratios / spike-in) from BAM files |
 | `collapse-bedgraph` | `collapse` | Collapse adjacent equal-score bins in a bedGraph |
 
 ## CLI Filter Flags
@@ -93,6 +98,9 @@ All subcommands that accept `FilterOptions` support:
 | `--barcode-allowlist` | — | Text file of cell barcodes (one per line) |
 | `--read-group` | — | Keep only this RG tag value |
 | `--tag` / `--tag-value` | — | Keep reads where TAG == VALUE |
+| `--ignore-duplicates` | off | Exclude PCR/optical duplicate reads |
+| `--ignore-secondary` | off | Exclude secondary alignments |
+| `--ignore-supplementary` | off | Exclude supplementary alignments |
 
 Old names (e.g. `--proper-pair`, `--min-fragment-length`, `--blacklisted-locations`, `--whitelisted-barcodes`, `--filter-tag`) are kept as compatibility aliases but canonical names above are preferred.
 
@@ -132,6 +140,17 @@ BamReadFilter::new(
 )
 ```
 
+`BamReadFilter::new()` stays 12-arg (non-breaking). Duplicate/secondary/supplementary exclusion, and every other optional constructor field, are also settable via chainable builder methods: `.with_exclude_duplicates(bool)`, `.with_exclude_secondary(bool)`, `.with_exclude_supplementary(bool)` (all default `false`), plus `.with_strand(...)`, `.with_proper_pair(...)`, `.with_min_mapq(...)`, `.with_min_length(...)`, `.with_max_length(...)`, `.with_read_group(...)`, `.with_blacklisted_locations(...)`, `.with_whitelisted_barcodes(...)`, `.with_filter_tag(...)`, `.with_filter_tag_value(...)`, `.with_min_fragment_length(...)`, `.with_max_fragment_length(...)`. Prefer `BamReadFilter::default()` + builder methods over `::new()` with many `None`s for new call sites.
+
+## Between-sample normalization (`bam-normalize`)
+
+Bins the genome, counts filtered reads/fragments per bin per sample (`bin_counts::count_bins`), then estimates a scaling factor per sample (`normalization_factors::compute_scale_factors`) that corrects for composition/technical bias — not just depth. Reports factors only; does not generate bigwigs. Apply the reported `scale_factor` to `bam-coverage -f` / `bigwig-aggregate --scale-factors`.
+
+- Methods: `tmm`, `csaw-background` (default — TMM on large background bins with the top `--exclude-top-percent` most-enriched bins dropped), `cpm`, `median-of-ratios`, `spike-in`.
+- `spike-in` reads mapped-read counts directly from the BAM index (`BamStats::mapped_reads_by_prefix`) — no BAM record scan, unfiltered by MAPQ/duplicates. It ignores `--bin-size` and requires `--exogenous-prefix`; it does not go through `bin_counts`/`compute_scale_factors` at all (handled as a separate branch in both the CLI and the Python binding).
+- All bin-count-based BAM files must share an identical chromosome name → length map (`bin_counts::count_bins` errors otherwise).
+- `--sample-sheet CSV` (with `sample`/`bam` columns) is an alternative to repeated `--bams`; sample names derived from `--bams` file stems are disambiguated (`_1`, `_2`, …) if they collide.
+
 ## Build
 
 ```bash
@@ -155,3 +174,4 @@ maturin build --release  # wheel
 
 - Main branch has protection, needs a PR to merge.
 - `cargo build` (workspace) fails at link stage with pyo3 undefined symbol errors (`_PyBaseObject_Type`, etc.) — Python headers not linked in the dev environment. Use `cargo build -p bamnado` or `cargo test -p bamnado` to build/test the Rust library and CLI without the Python bindings. The pyo3 cdylib in `bamnado-python/` requires `maturin` to build correctly.
+- Run `maturin develop` / `maturin build` from the **repo root** (where `pyproject.toml` lives, with `python-source = "bamnado-python/python"`), not from inside `bamnado-python/`. Running it from the subdirectory silently builds only the `_bamnado` extension module without the `bamnado` Python package wrapper, so `import bamnado` fails afterwards even though the build reports success.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ bamnado <command> --help            # Help for a specific command
 | `bigwig-compare` | `compare-bigwigs` | Compare two BigWig files bin by bin |
 | `bigwig-aggregate` | `aggregate-bigwigs` | Aggregate multiple BigWig files into one track |
 | `bigwig-infer-scale` | `infer-scale` | Infer scaling factor and library size from a normalised BigWig |
+| `bam-normalize` | `norm-factors` | Compute between-sample scaling factors from BAM files |
 | `collapse-bedgraph` | `collapse` | Collapse adjacent equal-score bins in a bedGraph |
 
 ### Read filtering
@@ -141,6 +142,9 @@ All coverage commands share common read filter flags:
 | `--barcode-allowlist` | — | Text file of cell barcodes (one per line) |
 | `--read-group` | — | Keep only this read group |
 | `--tag` / `--tag-value` | — | Keep reads where TAG == VALUE |
+| `--ignore-duplicates` | off | Exclude PCR/optical duplicate reads |
+| `--ignore-secondary` | off | Exclude secondary alignments |
+| `--ignore-supplementary` | off | Exclude supplementary alignments |
 
 ### Coverage-specific flags
 
@@ -241,6 +245,60 @@ bamnado collapse-bedgraph \
   --input signal.bedgraph \
   --output signal.collapsed.bedgraph
 ```
+
+#### Normalize between ChIP-seq samples
+
+```bash
+bamnado bam-normalize \
+  --bams chip1.bam chip2.bam chip3.bam \
+  --method csaw-background \
+  --bin-size 10000 \
+  --blacklist blacklist.bed
+```
+
+Apply the reported `scale_factor` for each sample to `bam-coverage -f` (or
+`bigwig-aggregate --scale-factors`) when generating tracks for that sample.
+
+## Between-sample normalization
+
+Comparing ChIP-seq / CUT&Tag / CUT&RUN samples side by side requires removing
+composition and technical bias, not just sequencing depth. A sample with a stronger
+pulldown has more of its library consumed by peaks, which deflates its background and
+makes every other region look artificially low relative to a shallower or weaker-pulldown
+sample. Simple total-count (CPM) scaling does not correct for this — it's the same
+problem `csaw::normFactors` / `edgeR::calcNormFactors` (TMM) solve in R/Bioconductor.
+
+`bamnado bam-normalize` bins the genome, counts filtered reads (or fragments) per bin per
+sample, and reports a per-sample scaling factor plus the underlying bin count matrix for
+downstream sanity checks (e.g. M-A plots). It reports factors only — it does not generate
+bigwigs itself.
+
+### Method choice
+
+| Method | When to use |
+| ------ | ----------- |
+| `csaw-background` (default) | Typical composition bias: TMM restricted to large background windows with the most-enriched bins excluded |
+| `tmm` | TMM over all bins, without excluding enriched regions |
+| `cpm` | Naive depth-only baseline, useful for comparison against the other methods |
+| `median-of-ratios` | A robust DESeq2-style alternative estimator |
+| `spike-in` | When a spike-in genome was used and is trusted more than a background estimate |
+
+### Applying the result
+
+`scale_factor` is centred on 1 (the geometric mean across samples), so it can be passed
+directly to `bam-coverage -f <factor>` or `bigwig-aggregate --scale-factors` for each
+corresponding sample.
+
+Use `--counts-out counts.tsv` to write the underlying bin count matrix (chrom, start, end,
+one column per sample) for QC, e.g. plotting an M-A plot to confirm the fitted factor sits
+at the centre of the trimmed M-value cloud.
+
+### Spike-in caveat
+
+The `spike-in` method reads mapped-read counts directly from each BAM's index (no BAM
+record scan), so those counts are **unfiltered** by MAPQ, duplicates, or
+secondary/supplementary status — the same basis as `bam-coverage`'s internal mapped-read
+count. `--exogenous-prefix` is required and `--bin-size` is ignored for this method.
 
 ## Python API
 
@@ -430,6 +488,52 @@ signal = bamnado.get_signal_for_chromosome(
 **Returns:** `numpy.ndarray` of dtype `float32` with length = chromosome size / bin_size
 
 **Note:** Fragment length filtering (`min_fragment_length`, `max_fragment_length`) requires paired-end BAM files and will raise `ValueError` on single-end data.
+
+### Between-sample scaling factors
+
+`compute_scale_factors` mirrors the `bam-normalize` CLI command — see
+[Between-sample normalization](#between-sample-normalization) for the underlying method.
+
+```python
+import bamnado
+
+result = bamnado.compute_scale_factors(
+    ["chip1.bam", "chip2.bam", "chip3.bam"],
+    method="csaw-background",
+    bin_size=10000,
+)
+print(result.sample_names, result.scale_factors)
+
+# Include the bin count matrix for QC (e.g. an M-A plot)
+result = bamnado.compute_scale_factors(
+    ["chip1.bam", "chip2.bam"],
+    method="tmm",
+    return_counts=True,
+)
+counts = result.counts()  # (n_bins, n_samples) uint64 array, or None
+```
+
+#### compute_scale_factors parameters
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `bam_paths` | `list[str]` | — | Input BAM file paths, one per sample |
+| `method` | `str` | `"csaw-background"` | `"tmm"`, `"csaw-background"`, `"cpm"`, `"median-of-ratios"`, or `"spike-in"` |
+| `bin_size` | `int` | `10000` | Genomic bin width in bp; ignored for `"spike-in"` |
+| `sample_names` | `list[str] \| None` | `None` | Defaults to each BAM's file stem, disambiguated if duplicated |
+| `exclude_top_percent` | `float` | `5.0` | `"csaw-background"` only: percent of highest-mean bins dropped before estimating |
+| `reference_sample` | `str \| None` | `None` | TMM reference sample; defaults to the one closest to the geometric mean |
+| `logratio_trim` | `float` | `0.3` | TMM trim fraction for M-values |
+| `sum_trim` | `float` | `0.05` | TMM trim fraction for A-values |
+| `exogenous_prefix` | `str \| None` | `None` | Required for `method="spike-in"` |
+| `use_fragment` | `bool` | `False` | Count fragments (pairs) instead of individual reads |
+| `ignore_scaffold_chromosomes` | `bool` | `True` | Skip scaffold / unplaced chromosomes |
+| `read_filter` | `ReadFilter \| None` | `None` | Applied per sample |
+| `return_counts` | `bool` | `False` | Populate `ScaleFactorResult.counts()` |
+
+**Returns:** `ScaleFactorResult` with `method`, `sample_names`, `library_sizes`,
+`norm_factors`, `scale_factors`, `reference_sample`, `n_bins_total`, `n_bins_used`, and
+(when `return_counts=True`) `counts()`, `bin_chroms`, `bin_starts`, `bin_ends`.
 
 ## Development
 

--- a/bamnado-python/python/bamnado/__init__.py
+++ b/bamnado-python/python/bamnado/__init__.py
@@ -1,3 +1,15 @@
-from ._bamnado import ReadFilter, get_signal_for_chromosome, __version__
+from ._bamnado import (
+    ReadFilter,
+    ScaleFactorResult,
+    compute_scale_factors,
+    get_signal_for_chromosome,
+    __version__,
+)
 
-__all__ = ["ReadFilter", "get_signal_for_chromosome", "__version__"]
+__all__ = [
+    "ReadFilter",
+    "ScaleFactorResult",
+    "compute_scale_factors",
+    "get_signal_for_chromosome",
+    "__version__",
+]

--- a/bamnado-python/python/bamnado/_bamnado.pyi
+++ b/bamnado-python/python/bamnado/_bamnado.pyi
@@ -1,5 +1,41 @@
 import numpy as np
 
+class ReadFilter:
+    """Configuration for filtering BAM reads.
+
+    Controls which reads are included in coverage calculations based on mapping
+    quality, read length, strand, paired-end flags, barcodes, and genomic blacklists.
+    """
+
+    min_mapq: int
+    proper_pair: bool
+    min_length: int
+    max_length: int
+    strand: str
+    min_fragment_length: int | None
+    max_fragment_length: int | None
+    blacklist_bed: str | None
+    whitelisted_barcodes: list[str] | None
+    read_group: str | None
+    filter_tag: str | None
+    filter_tag_value: str | None
+
+    def __init__(
+        self,
+        min_mapq: int = 0,
+        proper_pair: bool = False,
+        min_length: int = 0,
+        max_length: int = 1000,
+        strand: str = "both",
+        min_fragment_length: int | None = None,
+        max_fragment_length: int | None = None,
+        blacklist_bed: str | None = None,
+        whitelisted_barcodes: list[str] | None = None,
+        read_group: str | None = None,
+        filter_tag: str | None = None,
+        filter_tag_value: str | None = None,
+    ) -> None: ...
+
 def get_signal_for_chromosome(
     bam_path: str,
     chromosome_name: str,
@@ -7,6 +43,7 @@ def get_signal_for_chromosome(
     scale_factor: float,
     use_fragment: bool,
     ignore_scaffold_chromosomes: bool,
+    read_filter: ReadFilter | None = None,
 ) -> np.ndarray:
     """Get signal for a specific chromosome from a BAM file.
     Args:
@@ -16,8 +53,74 @@ def get_signal_for_chromosome(
         scale_factor (float): Factor to scale the signal.
         use_fragment (bool): Whether to use fragment length for signal calculation.
         ignore_scaffold_chromosomes (bool): Whether to ignore scaffold chromosomes.
+        read_filter (ReadFilter | None): Optional read filter configuration.
     Returns:
         np.ndarray: Array representing the signal for the specified chromosome.
+    """
+    ...
+
+class ScaleFactorResult:
+    """Result of a between-sample scaling factor computation."""
+
+    method: str
+    sample_names: list[str]
+    library_sizes: list[int]
+    norm_factors: list[float]
+    scale_factors: list[float]
+    reference_sample: str | None
+    n_bins_total: int
+    n_bins_used: int
+
+    def counts(self) -> np.ndarray | None:
+        """The (n_bins, n_samples) bin count matrix, or None if return_counts=False."""
+        ...
+
+    @property
+    def bin_chroms(self) -> list[str]: ...
+    @property
+    def bin_starts(self) -> list[int]: ...
+    @property
+    def bin_ends(self) -> list[int]: ...
+
+def compute_scale_factors(
+    bam_paths: list[str],
+    method: str = "csaw-background",
+    bin_size: int = 10000,
+    sample_names: list[str] | None = None,
+    exclude_top_percent: float = 5.0,
+    reference_sample: str | None = None,
+    logratio_trim: float = 0.3,
+    sum_trim: float = 0.05,
+    exogenous_prefix: str | None = None,
+    use_fragment: bool = False,
+    ignore_scaffold_chromosomes: bool = True,
+    read_filter: ReadFilter | None = None,
+    return_counts: bool = False,
+) -> ScaleFactorResult:
+    """Compute between-sample scaling factors from BAM files.
+
+    Args:
+        bam_paths (list[str]): Input BAM file paths, one per sample.
+        method (str): Normalization method: "tmm", "csaw-background" (default), "cpm",
+            "median-of-ratios", or "spike-in".
+        bin_size (int): Genomic bin width in base pairs. Ignored for "spike-in".
+        sample_names (list[str] | None): Sample names, same length/order as bam_paths.
+            Defaults to each BAM file's stem, disambiguated if duplicated.
+        exclude_top_percent (float): Percentage of highest-mean-count bins dropped
+            before estimating ("csaw-background" only).
+        reference_sample (str | None): Sample name to use as the TMM reference.
+        logratio_trim (float): TMM trim fraction for M-values.
+        sum_trim (float): TMM trim fraction for A-values.
+        exogenous_prefix (str | None): Reference-name prefix identifying spike-in
+            sequences. Required for method="spike-in".
+        use_fragment (bool): Count fragments (pairs) instead of individual reads.
+        ignore_scaffold_chromosomes (bool): Skip scaffold / unplaced chromosomes.
+        read_filter (ReadFilter | None): Read filter configuration, applied per sample.
+        return_counts (bool): If True, populate ScaleFactorResult.counts() with the
+            underlying bin count matrix.
+
+    Returns:
+        ScaleFactorResult: The computed scaling factors and (optionally) count matrix.
     """
     ...
 

--- a/bamnado-python/src/lib.rs
+++ b/bamnado-python/src/lib.rs
@@ -7,12 +7,14 @@
 //!
 //! *   `ReadFilter`: Configuration for filtering BAM reads.
 //! *   `get_signal_for_chromosome`: Calculates coverage signal for a chromosome.
+//! *   `compute_scale_factors`: Computes between-sample scaling factors from BAM files.
+//! *   `ScaleFactorResult`: Result of a between-sample scaling factor computation.
 
 use ahash::HashSet;
 use bamnado::{bam_utils, coverage_analysis, read_filter::BamReadFilter, signal_normalization};
 use bio_types::strand::Strand;
 use ndarray::prelude::*;
-use numpy::{PyArray1, prelude::*};
+use numpy::{PyArray1, PyArray2, prelude::*};
 use pyo3::exceptions::{PyKeyError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use std::path::PathBuf;
@@ -299,6 +301,260 @@ mod _bamnado {
 
         let numpy_array = array.into_pyarray(py).unbind();
         Ok(numpy_array)
+    }
+
+    /// Result of a between-sample scaling factor computation.
+    ///
+    /// See `compute_scale_factors` for how these fields are derived.
+    #[pyclass]
+    pub struct ScaleFactorResult {
+        #[pyo3(get)]
+        pub method: String,
+        #[pyo3(get)]
+        pub sample_names: Vec<String>,
+        #[pyo3(get)]
+        pub library_sizes: Vec<u64>,
+        #[pyo3(get)]
+        pub norm_factors: Vec<f64>,
+        #[pyo3(get)]
+        pub scale_factors: Vec<f64>,
+        #[pyo3(get)]
+        pub reference_sample: Option<String>,
+        #[pyo3(get)]
+        pub n_bins_total: usize,
+        #[pyo3(get)]
+        pub n_bins_used: usize,
+        counts: Option<Array2<u64>>,
+        bin_chroms: Vec<String>,
+        bin_starts: Vec<u64>,
+        bin_ends: Vec<u64>,
+    }
+
+    #[pymethods]
+    impl ScaleFactorResult {
+        /// The `(n_bins, n_samples)` bin count matrix, or `None` if `return_counts=False`.
+        fn counts<'py>(&self, py: Python<'py>) -> Option<Py<PyArray2<u64>>> {
+            self.counts.as_ref().map(|c| c.to_pyarray(py).unbind())
+        }
+
+        /// Chromosome name for each row of `counts()`. Empty if `return_counts=False`.
+        #[getter]
+        fn bin_chroms(&self) -> Vec<String> {
+            self.bin_chroms.clone()
+        }
+
+        /// 1-based inclusive start position for each row of `counts()`.
+        #[getter]
+        fn bin_starts(&self) -> Vec<u64> {
+            self.bin_starts.clone()
+        }
+
+        /// 1-based inclusive end position for each row of `counts()`.
+        #[getter]
+        fn bin_ends(&self) -> Vec<u64> {
+            self.bin_ends.clone()
+        }
+
+        fn __repr__(&self) -> String {
+            format!(
+                "ScaleFactorResult(method={:?}, sample_names={:?}, scale_factors={:?})",
+                self.method, self.sample_names, self.scale_factors
+            )
+        }
+    }
+
+    /// Compute between-sample scaling factors from BAM files.
+    ///
+    /// Bins the genome, counts filtered reads (or fragments) per bin per sample, and
+    /// estimates a scaling factor for each sample that removes composition and technical
+    /// bias — e.g. so that a stronger pulldown, which consumes more of its library on peaks
+    /// and deflates its background, does not make every other region in that sample look
+    /// artificially low relative to the others. Apply the returned `scale_factors` to
+    /// ``bam-coverage -f`` / ``bigwig-aggregate --scale-factors``.
+    ///
+    /// Args:
+    ///     bam_paths (list[str]): Input BAM file paths, one per sample.
+    ///     method (str): Normalization method: ``"tmm"``, ``"csaw-background"`` (default),
+    ///         ``"cpm"``, ``"median-of-ratios"``, or ``"spike-in"``.
+    ///     bin_size (int): Genomic bin width in base pairs. Ignored for ``"spike-in"``.
+    ///     sample_names (list[str] | None): Sample names, same length/order as *bam_paths*.
+    ///         Defaults to each BAM file's stem, disambiguated if duplicated.
+    ///     exclude_top_percent (float): Percentage of highest-mean-count bins dropped before
+    ///         estimating (``"csaw-background"`` only). Default: 5.0.
+    ///     reference_sample (str | None): Sample name to use as the TMM reference. Defaults
+    ///         to the sample whose bin total is closest to the geometric mean.
+    ///     logratio_trim (float): TMM trim fraction for M-values. Default: 0.3.
+    ///     sum_trim (float): TMM trim fraction for A-values. Default: 0.05.
+    ///     exogenous_prefix (str | None): Reference-name prefix identifying spike-in
+    ///         sequences. Required for ``method="spike-in"``.
+    ///     use_fragment (bool): Count fragments (pairs) instead of individual read
+    ///         alignments. Default: False.
+    ///     ignore_scaffold_chromosomes (bool): Skip scaffold / unplaced chromosomes when
+    ///         building the bin grid. Default: True.
+    ///     read_filter (ReadFilter | None): Read filter configuration, applied per sample.
+    ///         Uses default settings if None.
+    ///     return_counts (bool): If True, populate ``ScaleFactorResult.counts()`` with the
+    ///         underlying bin count matrix (for QC / M-A plots). Default: False.
+    ///
+    /// Returns:
+    ///     ScaleFactorResult: The computed scaling factors and (optionally) count matrix.
+    ///
+    /// Raises:
+    ///     ValueError: If *method* or *sample_names* is invalid, or *exogenous_prefix* is
+    ///         missing for ``method="spike-in"``.
+    ///     RuntimeError: If a BAM file cannot be read or the count/estimation step fails
+    ///         (e.g. mismatched chromosome sets between samples).
+    #[allow(clippy::too_many_arguments)]
+    #[pyfunction]
+    #[pyo3(signature = (
+        bam_paths,
+        method="csaw-background",
+        bin_size=10000,
+        sample_names=None,
+        exclude_top_percent=5.0,
+        reference_sample=None,
+        logratio_trim=0.3,
+        sum_trim=0.05,
+        exogenous_prefix=None,
+        use_fragment=false,
+        ignore_scaffold_chromosomes=true,
+        read_filter=None,
+        return_counts=false
+    ))]
+    fn compute_scale_factors(
+        bam_paths: Vec<String>,
+        method: &str,
+        bin_size: u64,
+        sample_names: Option<Vec<String>>,
+        exclude_top_percent: f64,
+        reference_sample: Option<String>,
+        logratio_trim: f64,
+        sum_trim: f64,
+        exogenous_prefix: Option<String>,
+        use_fragment: bool,
+        ignore_scaffold_chromosomes: bool,
+        read_filter: Option<ReadFilter>,
+        return_counts: bool,
+    ) -> PyResult<ScaleFactorResult> {
+        use bamnado::normalization_factors::NormFactorMethod;
+
+        let method_enum = match method {
+            "tmm" => NormFactorMethod::Tmm,
+            "csaw-background" => NormFactorMethod::CsawBackground,
+            "cpm" => NormFactorMethod::Cpm,
+            "median-of-ratios" => NormFactorMethod::MedianOfRatios,
+            "spike-in" => NormFactorMethod::SpikeIn,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "Invalid method '{other}': must be one of \"tmm\", \"csaw-background\", \
+                     \"cpm\", \"median-of-ratios\", \"spike-in\""
+                )));
+            }
+        };
+
+        if bam_paths.is_empty() {
+            return Err(PyValueError::new_err("At least one BAM file is required"));
+        }
+        let bam_paths: Vec<PathBuf> = bam_paths.into_iter().map(PathBuf::from).collect();
+
+        let sample_names: Vec<String> = match sample_names {
+            Some(names) => {
+                if names.len() != bam_paths.len() {
+                    return Err(PyValueError::new_err(format!(
+                        "sample_names length ({}) does not match bam_paths length ({})",
+                        names.len(),
+                        bam_paths.len()
+                    )));
+                }
+                names
+            }
+            None => bam_paths
+                .iter()
+                .map(|p| {
+                    p.file_stem()
+                        .and_then(|s| s.to_str())
+                        .map(String::from)
+                        .unwrap_or_else(|| p.display().to_string())
+                })
+                .collect(),
+        };
+
+        let bam_stats: Vec<bam_utils::BamStats> = bam_paths
+            .iter()
+            .map(|p| bam_utils::BamStats::new(p.clone()).map_err(anyhow_to_pyerr))
+            .collect::<PyResult<Vec<_>>>()?;
+
+        let mut counts_data: Option<(Array2<u64>, Vec<String>, Vec<u64>, Vec<u64>)> = None;
+
+        let result = if matches!(method_enum, NormFactorMethod::SpikeIn) {
+            let prefix = exogenous_prefix.ok_or_else(|| {
+                PyValueError::new_err("exogenous_prefix is required for method=\"spike-in\"")
+            })?;
+            bamnado::normalization_factors::spike_in_scale_factors(
+                &bam_stats,
+                &sample_names,
+                &prefix,
+            )
+            .map_err(anyhow_to_pyerr)?
+        } else {
+            let filters: Vec<BamReadFilter> = bam_stats
+                .iter()
+                .map(|stats| build_bam_read_filter(read_filter.clone(), stats))
+                .collect::<PyResult<Vec<_>>>()?;
+
+            let counts = bamnado::bin_counts::count_bins(
+                &bam_paths,
+                &sample_names,
+                bin_size,
+                &filters,
+                use_fragment,
+                ignore_scaffold_chromosomes,
+            )
+            .map_err(anyhow_to_pyerr)?;
+
+            let params = bamnado::normalization_factors::NormFactorParams {
+                reference_sample,
+                logratio_trim,
+                sum_trim,
+                exclude_top_percent,
+                ..Default::default()
+            };
+            let scale_factors = bamnado::normalization_factors::compute_scale_factors(
+                &counts,
+                &method_enum,
+                &params,
+            )
+            .map_err(anyhow_to_pyerr)?;
+
+            if return_counts {
+                let bin_chroms = counts.bins.iter().map(|b| b.chrom.clone()).collect();
+                let bin_starts = counts.bins.iter().map(|b| b.start).collect();
+                let bin_ends = counts.bins.iter().map(|b| b.end).collect();
+                counts_data = Some((counts.counts, bin_chroms, bin_starts, bin_ends));
+            }
+
+            scale_factors
+        };
+
+        let (counts, bin_chroms, bin_starts, bin_ends) = match counts_data {
+            Some((c, bc, bs, be)) => (Some(c), bc, bs, be),
+            None => (None, Vec::new(), Vec::new(), Vec::new()),
+        };
+
+        Ok(ScaleFactorResult {
+            method: result.method,
+            sample_names: result.sample_names,
+            library_sizes: result.library_sizes,
+            norm_factors: result.norm_factors,
+            scale_factors: result.scale_factors,
+            reference_sample: result.reference_sample,
+            n_bins_total: result.n_bins_total,
+            n_bins_used: result.n_bins_used,
+            counts,
+            bin_chroms,
+            bin_starts,
+            bin_ends,
+        })
     }
 
     #[pyfunction]

--- a/bamnado/src/bam_utils.rs
+++ b/bamnado/src/bam_utils.rs
@@ -18,11 +18,13 @@ use noodles::core::{Position, Region};
 use noodles::sam::header::record::value::{Map, map::Program, map::program::tag as pg_tag};
 use noodles::{bam, bed, sam};
 use polars::prelude::*;
+use regex::Regex;
 use rust_lapper::Interval;
 use rust_lapper::Lapper;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::OnceLock;
 
 /// The cell barcode tag (CB).
 pub const CB: [u8; 2] = [b'C', b'B'];
@@ -31,6 +33,62 @@ pub type Iv = Interval<usize, u32>;
 const BAMNADO_PROGRAM_ID: &str = "bamnado";
 const BAMNADO_PROGRAM_NAME: &str = "bamnado";
 const BAMNADO_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Check if a chromosome name is a scaffold / unplaced contig.
+pub(crate) fn is_scaffold(name: &str) -> bool {
+    static SCAFFOLD_REGEX: OnceLock<Regex> = OnceLock::new();
+    SCAFFOLD_REGEX
+        .get_or_init(|| Regex::new(r"^chrUn|_alt$|_random$").unwrap())
+        .is_match(name)
+}
+
+/// Bin a `Lapper` of read intervals into fixed-width bins over `[region_start, region_end)`.
+///
+/// Coordinates are 1-based (noodles/SAM convention); see `BamStats::genome_chunks`.
+pub fn bin_intervals(
+    lapper: &Lapper<usize, u32>,
+    region_start: usize,
+    region_end: usize,
+    bin_size: u64,
+    collapse: bool,
+) -> Vec<Iv> {
+    let mut bin_counts: Vec<Iv> = Vec::new();
+    let mut start = region_start;
+    while start < region_end {
+        let end = (start + bin_size as usize).min(region_end);
+        let count = lapper.count(start, end);
+        match collapse {
+            true => {
+                if let Some(last) = bin_counts.last_mut() {
+                    if last.val == count as u32 {
+                        last.stop = end;
+                    } else {
+                        bin_counts.push(Iv {
+                            start,
+                            stop: end,
+                            val: count as u32,
+                        });
+                    }
+                } else {
+                    bin_counts.push(Iv {
+                        start,
+                        stop: end,
+                        val: count as u32,
+                    });
+                }
+            }
+            false => {
+                bin_counts.push(Iv {
+                    start,
+                    stop: end,
+                    val: count as u32,
+                });
+            }
+        }
+        start = end;
+    }
+    bin_counts
+}
 
 /// Represents the strand of a genomic feature.
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
@@ -460,6 +518,28 @@ impl BamStats {
     /// Returns the number of mapped reads.
     pub fn n_mapped(&self) -> u64 {
         self.n_mapped
+    }
+
+    /// Mapped reads split by reference-name prefix, read from the BAI index (no record scan).
+    ///
+    /// These counts come from BAI index metadata, so they are unfiltered by MAPQ,
+    /// duplicate, or secondary/supplementary status — the same basis as [`BamStats::n_mapped`].
+    ///
+    /// # Returns
+    ///
+    /// `(with_prefix, without_prefix)` — mapped read counts for reference sequences whose
+    /// name starts with `prefix`, and for all other reference sequences, respectively.
+    pub fn mapped_reads_by_prefix(&self, prefix: &str) -> (u64, u64) {
+        let mut with_prefix = 0u64;
+        let mut without_prefix = 0u64;
+        for (name, stats) in self.chrom_stats.iter() {
+            if name.starts_with(prefix) {
+                with_prefix += stats.mapped;
+            } else {
+                without_prefix += stats.mapped;
+            }
+        }
+        (with_prefix, without_prefix)
     }
 
     /// Returns the number of unmapped reads.

--- a/bamnado/src/bam_utils.rs
+++ b/bamnado/src/bam_utils.rs
@@ -27,7 +27,7 @@ use std::str::FromStr;
 use std::sync::OnceLock;
 
 /// The cell barcode tag (CB).
-pub const CB: [u8; 2] = [b'C', b'B'];
+pub const CB: [u8; 2] = *b"CB";
 /// Type alias for an interval with a `u32` value.
 pub type Iv = Interval<usize, u32>;
 const BAMNADO_PROGRAM_ID: &str = "bamnado";
@@ -359,7 +359,7 @@ impl BamStats {
 
         let mut mapped_record_count = 0;
 
-        for (_, stats) in chrom_stats.iter() {
+        for stats in chrom_stats.values() {
             mapped_record_count += stats.mapped;
             unmapped_record_count += stats.unmapped;
         }

--- a/bamnado/src/bin_counts.rs
+++ b/bamnado/src/bin_counts.rs
@@ -1,0 +1,335 @@
+//! # Bin Counts Module
+//!
+//! This module computes a shared genomic bin grid across one or more BAM files and
+//! counts filtered reads (or fragments) per bin per sample. It supports:
+//! *   A single shared bin grid across samples, required for between-sample comparison.
+//! *   Parallel per-chunk counting, reusing the same binning machinery as `coverage_analysis`.
+//! *   Conversion of the resulting count matrix to a Polars `DataFrame` for QC / M-A plots.
+
+use std::path::PathBuf;
+
+use crate::bam_utils::{BamStats, Iv, bin_intervals, get_bam_header, is_scaffold, progress_bar};
+use crate::genomic_intervals::IntervalMaker;
+use crate::read_filter::BamReadFilter;
+use ahash::HashMap;
+use anyhow::{Context, Result, bail};
+use indicatif::ParallelProgressIterator;
+use ndarray::Array2;
+use noodles::bam;
+use polars::prelude::*;
+use rayon::prelude::*;
+use rust_lapper::Lapper;
+
+/// One genomic bin in the count matrix.
+///
+/// Coordinates are 1-based (noodles/SAM convention), matching `BamStats`.
+#[derive(Debug, Clone)]
+pub struct BinRegion {
+    /// Chromosome / reference sequence name.
+    pub chrom: String,
+    /// 1-based inclusive start position.
+    pub start: u64,
+    /// 1-based inclusive end position.
+    pub end: u64,
+}
+
+/// A sample × bin read-count matrix, produced by [`count_bins`].
+pub struct BinCounts {
+    /// Sample names, in column order matching `counts`.
+    pub sample_names: Vec<String>,
+    /// The bin size used to build the grid.
+    pub bin_size: u64,
+    /// The bin grid, in row order matching `counts`.
+    pub bins: Vec<BinRegion>,
+    /// Read counts, shape `(n_bins, n_samples)`.
+    pub counts: Array2<u64>,
+    /// Post-filter library size (total retained reads/fragments) per sample.
+    pub library_sizes: Vec<u64>,
+}
+
+impl BinCounts {
+    /// Convert the bin count matrix into a Polars `DataFrame` for QC (e.g. M-A plots).
+    ///
+    /// # Returns
+    ///
+    /// A `DataFrame` with columns `chrom`, `start`, `end`, and one `f64` column per sample,
+    /// named after the corresponding entry in `sample_names`.
+    pub fn to_polars(&self) -> Result<DataFrame> {
+        let n_bins = self.bins.len();
+        let mut chroms = Vec::with_capacity(n_bins);
+        let mut starts = Vec::with_capacity(n_bins);
+        let mut ends = Vec::with_capacity(n_bins);
+        for bin in &self.bins {
+            chroms.push(bin.chrom.clone());
+            starts.push(bin.start);
+            ends.push(bin.end);
+        }
+
+        let mut columns = vec![
+            Column::new("chrom".into(), chroms),
+            Column::new("start".into(), starts),
+            Column::new("end".into(), ends),
+        ];
+
+        for (s, name) in self.sample_names.iter().enumerate() {
+            let col: Vec<f64> = self.counts.column(s).iter().map(|&c| c as f64).collect();
+            columns.push(Column::new(name.as_str().into(), col));
+        }
+
+        Ok(DataFrame::new(columns)?)
+    }
+}
+
+/// Bin-count reads (or fragments) across one or more BAM files onto a shared genomic bin grid.
+///
+/// All input BAM files must share an identical chromosome name → length mapping; this is
+/// required so that a single bin grid can be used to compare samples bin-for-bin.
+///
+/// # Arguments
+///
+/// * `bam_paths` - Input BAM files, one per sample.
+/// * `sample_names` - Sample names, same length and order as `bam_paths`.
+/// * `bin_size` - Genomic bin width in base pairs.
+/// * `filters` - Per-sample read filter, same length and order as `bam_paths`.
+/// * `use_fragment` - Count fragments (read pairs) instead of individual read alignments.
+/// * `ignore_scaffold_chromosomes` - Skip scaffold / unplaced chromosomes when building the grid.
+///
+/// # Returns
+///
+/// A [`BinCounts`] with the count matrix and per-sample post-filter library sizes.
+pub fn count_bins(
+    bam_paths: &[PathBuf],
+    sample_names: &[String],
+    bin_size: u64,
+    filters: &[BamReadFilter],
+    use_fragment: bool,
+    ignore_scaffold_chromosomes: bool,
+) -> Result<BinCounts> {
+    anyhow::ensure!(
+        !bam_paths.is_empty(),
+        "At least one BAM file is required for bin counting"
+    );
+    anyhow::ensure!(
+        bam_paths.len() == sample_names.len(),
+        "Number of BAM paths ({}) does not match number of sample names ({})",
+        bam_paths.len(),
+        sample_names.len()
+    );
+    anyhow::ensure!(
+        bam_paths.len() == filters.len(),
+        "Number of BAM paths ({}) does not match number of filters ({})",
+        bam_paths.len(),
+        filters.len()
+    );
+
+    // Build per-sample BamStats and validate a shared chromosome grid.
+    let bam_stats: Vec<BamStats> = bam_paths
+        .iter()
+        .map(|p| {
+            BamStats::new(p.clone())
+                .with_context(|| format!("Failed to read BAM stats for {}", p.display()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let reference_chromsizes = bam_stats[0].chromsizes_ref_name()?;
+    for (stats, path) in bam_stats.iter().zip(bam_paths.iter()).skip(1) {
+        let chromsizes = stats.chromsizes_ref_name()?;
+        if chromsizes != reference_chromsizes {
+            bail!(
+                "Chromosome name/length mismatch between BAM files: {} does not match {}. \
+                 bam-normalize requires all input BAM files to share an identical set of \
+                 reference sequences so that a common bin grid can be used.",
+                path.display(),
+                bam_paths[0].display()
+            );
+        }
+    }
+
+    // Build the global bin grid: one contiguous block of bins per chromosome, in
+    // deterministic (sorted) chromosome name order.
+    let mut chrom_names: Vec<String> = reference_chromsizes.keys().cloned().collect();
+    if ignore_scaffold_chromosomes {
+        chrom_names.retain(|name| !is_scaffold(name));
+    }
+    chrom_names.sort();
+
+    let mut bins = Vec::new();
+    let mut chrom_offsets: HashMap<String, usize> = HashMap::default();
+    for chrom in &chrom_names {
+        chrom_offsets.insert(chrom.clone(), bins.len());
+        let length = reference_chromsizes[chrom];
+        let mut start = 1u64;
+        while start <= length {
+            let end = (start + bin_size - 1).min(length);
+            bins.push(BinRegion {
+                chrom: chrom.clone(),
+                start,
+                end,
+            });
+            start = end + 1;
+        }
+    }
+    let n_bins = bins.len();
+    anyhow::ensure!(
+        n_bins > 0,
+        "No bins produced; check --bin-size and --ignore-scaffolds"
+    );
+
+    let mut counts = Array2::<u64>::zeros((n_bins, bam_paths.len()));
+    let mut library_sizes = Vec::with_capacity(bam_paths.len());
+
+    for (s, ((bam_path, stats), filter)) in bam_paths
+        .iter()
+        .zip(bam_stats.iter())
+        .zip(filters.iter())
+        .enumerate()
+    {
+        let header = get_bam_header(bam_path.clone())?;
+        let chromsizes_refid = stats.chromsizes_ref_id()?;
+        let genomic_chunks: Vec<_> = stats
+            .genome_chunks(bin_size)?
+            .into_iter()
+            .filter(|region| {
+                if !ignore_scaffold_chromosomes {
+                    return true;
+                }
+                let name = region.name().to_owned().to_string();
+                !is_scaffold(&name)
+            })
+            .collect();
+        let n_total_chunks = genomic_chunks.len();
+
+        let chunk_results: Vec<(String, usize, u32)> = genomic_chunks
+            .into_par_iter()
+            .progress_with(progress_bar(
+                n_total_chunks as u64,
+                format!("Counting bins for {}", sample_names[s]),
+            ))
+            .map(|region| -> Result<Vec<(String, usize, u32)>> {
+                let mut reader = bam::io::indexed_reader::Builder::default()
+                    .build_from_path(bam_path)
+                    .context("Failed to open BAM file")?;
+                let records = reader.query(&header, &region)?;
+                let intervals: Vec<Iv> = records
+                    .records()
+                    .filter_map(|record| record.ok())
+                    .filter_map(|record| {
+                        IntervalMaker::new(
+                            record,
+                            &header,
+                            &chromsizes_refid,
+                            filter,
+                            use_fragment,
+                            None,
+                            None,
+                        )
+                        .coords()
+                        .map(|(start_pos, end_pos, _dtlen)| Iv {
+                            start: start_pos,
+                            stop: end_pos,
+                            val: 1,
+                        })
+                    })
+                    .collect();
+
+                let lapper = Lapper::new(intervals);
+                let region_interval = region.interval();
+                let region_start = region_interval
+                    .start()
+                    .context("Failed to get region start")?
+                    .get();
+                let region_end = region_interval
+                    .end()
+                    .context("Failed to get region end")?
+                    .get();
+
+                let chrom_name = region.name().to_owned().to_string();
+                let bin_counts = bin_intervals(&lapper, region_start, region_end, bin_size, false);
+                Ok(bin_counts
+                    .into_iter()
+                    .map(|iv| (chrom_name.clone(), iv.start, iv.val))
+                    .collect())
+            })
+            .fold(
+                || Ok(Vec::new()),
+                |acc: Result<Vec<(String, usize, u32)>>,
+                 result: Result<Vec<(String, usize, u32)>>| {
+                    let mut acc = acc?;
+                    acc.extend(result?);
+                    Ok(acc)
+                },
+            )
+            .reduce(
+                || Ok(Vec::new()),
+                |acc: Result<Vec<(String, usize, u32)>>, b: Result<Vec<(String, usize, u32)>>| {
+                    let mut acc = acc?;
+                    acc.extend(b?);
+                    Ok(acc)
+                },
+            )?;
+
+        for (chrom, start, count) in chunk_results {
+            let offset = *chrom_offsets.get(&chrom).ok_or_else(|| {
+                anyhow::anyhow!("Chromosome {chrom} not part of the shared bin grid")
+            })?;
+            let bin_idx_in_chrom = ((start as u64 - 1) / bin_size) as usize;
+            counts[[offset + bin_idx_in_chrom, s]] = count as u64;
+        }
+
+        library_sizes.push(filter.stats().n_reads_after_filtering());
+    }
+
+    Ok(BinCounts {
+        sample_names: sample_names.to_vec(),
+        bin_size,
+        bins,
+        counts,
+        library_sizes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::read_filter::BamReadFilter;
+
+    fn get_test_data_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("Failed to get workspace root")
+            .join("test/data")
+    }
+
+    #[test]
+    fn test_count_bins_same_bam_twice_gives_identical_columns() {
+        let bam_file = get_test_data_dir().join("test.bam");
+        let bam_paths = vec![bam_file.clone(), bam_file];
+        let sample_names = vec!["a".to_string(), "b".to_string()];
+        let filters = vec![BamReadFilter::default(), BamReadFilter::default()];
+
+        let counts = count_bins(&bam_paths, &sample_names, 10_000, &filters, false, true)
+            .expect("count_bins failed");
+
+        assert!(!counts.bins.is_empty(), "Expected at least one bin");
+        assert_eq!(counts.library_sizes[0], counts.library_sizes[1]);
+        assert!(counts.library_sizes[0] > 0);
+
+        let total: u64 = counts.counts.iter().sum();
+        assert!(total > 0, "Expected non-zero counts");
+
+        for row in counts.counts.rows() {
+            assert_eq!(row[0], row[1]);
+        }
+    }
+
+    #[test]
+    fn test_count_bins_mismatched_bam_paths_and_sample_names_errors() {
+        let bam_file = get_test_data_dir().join("test.bam");
+        let bam_paths = vec![bam_file];
+        let sample_names = vec!["a".to_string(), "b".to_string()];
+        let filters = vec![BamReadFilter::default()];
+
+        let result = count_bins(&bam_paths, &sample_names, 10_000, &filters, false, true);
+        assert!(result.is_err());
+    }
+}

--- a/bamnado/src/coverage_analysis.rs
+++ b/bamnado/src/coverage_analysis.rs
@@ -9,9 +9,8 @@
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::path::PathBuf;
-use std::sync::OnceLock;
 
-use crate::bam_utils::{BamStats, Iv, get_bam_header, progress_bar};
+use crate::bam_utils::{BamStats, Iv, bin_intervals, get_bam_header, is_scaffold, progress_bar};
 use crate::genomic_intervals::{IntervalMaker, Shift, Truncate};
 use crate::read_filter::BamReadFilter;
 use crate::signal_normalization::NormalizationMethod;
@@ -31,16 +30,7 @@ use noodles::bam;
 use polars::lazy::dsl::col;
 use polars::prelude::*;
 use rayon::prelude::*;
-use regex::Regex;
 use rust_lapper::Lapper;
-
-/// Check if a chromosome name is a scaffold.
-fn is_scaffold(name: &str) -> bool {
-    static SCAFFOLD_REGEX: OnceLock<Regex> = OnceLock::new();
-    SCAFFOLD_REGEX
-        .get_or_init(|| Regex::new(r"^chrUn|_alt$|_random$").unwrap())
-        .is_match(name)
-}
 
 fn shift_is_noop(shift: Shift) -> bool {
     shift.five_prime == 0
@@ -289,6 +279,18 @@ impl BamPileup {
                 stats.n_failed_fragment_length()
             );
         }
+        if stats.n_failed_duplicate() > 0 {
+            debug!("  - Filtered as duplicate: {}", stats.n_failed_duplicate());
+        }
+        if stats.n_failed_secondary() > 0 {
+            debug!("  - Filtered as secondary: {}", stats.n_failed_secondary());
+        }
+        if stats.n_failed_supplementary() > 0 {
+            debug!(
+                "  - Filtered as supplementary: {}",
+                stats.n_failed_supplementary()
+            );
+        }
     }
 
     /// Create a new [`BamPileup`].
@@ -386,44 +388,16 @@ impl BamPileup {
                     .end()
                     .context("Failed to get region end")?
                     .get();
-                let mut bin_counts: Vec<Iv> = Vec::new();
                 // Bin coordinates are 1-based (noodles/SAM convention); region_start comes
                 // from Position::get() which is always ≥ 1. Conversion to 0-based happens
                 // at write time in to_bigwig().
-                let mut start = region_start;
-                while start < region_end {
-                    let end = (start + self.bin_size as usize).min(region_end);
-                    let count = lapper.count(start, end);
-                    match self.collapse {
-                        true => {
-                            if let Some(last) = bin_counts.last_mut() {
-                                if last.val == count as u32 {
-                                    last.stop = end;
-                                } else {
-                                    bin_counts.push(Iv {
-                                        start,
-                                        stop: end,
-                                        val: count as u32,
-                                    });
-                                }
-                            } else {
-                                bin_counts.push(Iv {
-                                    start,
-                                    stop: end,
-                                    val: count as u32,
-                                });
-                            }
-                        }
-                        false => {
-                            bin_counts.push(Iv {
-                                start,
-                                stop: end,
-                                val: count as u32,
-                            });
-                        }
-                    }
-                    start = end;
-                }
+                let bin_counts = bin_intervals(
+                    &lapper,
+                    region_start,
+                    region_end,
+                    self.bin_size,
+                    self.collapse,
+                );
                 Ok(bin_counts)
             })
             // Combine the results from parallel threads, propagating any errors.
@@ -521,42 +495,13 @@ impl BamPileup {
                     .context("Failed to get region end")?
                     .get();
 
-                let mut bin_counts: Vec<rust_lapper::Interval<usize, u32>> = Vec::new();
-                let mut start = region_start;
-                while start < region_end {
-                    let end = (start + self.bin_size as usize).min(region_end);
-                    let count = lapper.count(start, end);
-
-                    match self.collapse {
-                        true => {
-                            if let Some(last) = bin_counts.last_mut() {
-                                if last.val == count as u32 {
-                                    last.stop = end;
-                                } else {
-                                    bin_counts.push(rust_lapper::Interval {
-                                        start,
-                                        stop: end,
-                                        val: count as u32,
-                                    });
-                                }
-                            } else {
-                                bin_counts.push(rust_lapper::Interval {
-                                    start,
-                                    stop: end,
-                                    val: count as u32,
-                                });
-                            }
-                        }
-                        false => {
-                            bin_counts.push(rust_lapper::Interval {
-                                start,
-                                stop: end,
-                                val: count as u32,
-                            });
-                        }
-                    }
-                    start = end;
-                }
+                let bin_counts = bin_intervals(
+                    &lapper,
+                    region_start,
+                    region_end,
+                    self.bin_size,
+                    self.collapse,
+                );
 
                 Ok((region.name().to_owned().to_string(), bin_counts))
             })

--- a/bamnado/src/lib.rs
+++ b/bamnado/src/lib.rs
@@ -17,8 +17,10 @@
 //! *   [`bam_modifier`]: Tools for modifying BAM records.
 //! *   [`bam_splitter`]: Functionality for splitting BAM files.
 //! *   [`bam_utils`]: General utilities and statistics for BAM files.
+//! *   [`bin_counts`]: Parallel per-bin read counting across BAM files.
 //! *   [`coverage_analysis`]: Core logic for generating coverage tracks.
 //! *   [`genomic_intervals`]: Handling of genomic coordinates and intervals.
+//! *   [`normalization_factors`]: Between-sample scaling factor estimation (TMM, CPM, etc.).
 //! *   [`read_filter`]: Structures and traits for filtering reads.
 //! *   [`signal_normalization`]: Normalization strategies for coverage data.
 //! *   [`spike_in_analysis`]: Analysis tools for spike-in normalization.
@@ -32,8 +34,10 @@ pub mod bam_utils;
 pub mod bedgraph_utils;
 pub mod bigwig_compare;
 pub mod bigwig_infer_scale;
+pub mod bin_counts;
 pub mod coverage_analysis;
 pub mod genomic_intervals;
+pub mod normalization_factors;
 pub mod read_filter;
 pub mod signal_normalization;
 pub mod spike_in_analysis;

--- a/bamnado/src/main.rs
+++ b/bamnado/src/main.rs
@@ -127,6 +127,22 @@ struct FilterOptions {
         value_name = "BP"
     )]
     max_fragment_length: Option<u32>,
+
+    /// Exclude PCR/optical duplicate reads.
+    #[arg(
+        long = "ignore-duplicates",
+        visible_alias = "no-duplicates",
+        action = clap::ArgAction::SetTrue
+    )]
+    ignore_duplicates: bool,
+
+    /// Exclude secondary alignments.
+    #[arg(long = "ignore-secondary", action = clap::ArgAction::SetTrue)]
+    ignore_secondary: bool,
+
+    /// Exclude supplementary alignments.
+    #[arg(long = "ignore-supplementary", action = clap::ArgAction::SetTrue)]
+    ignore_supplementary: bool,
 }
 
 // Common coverage options for both single and multi-BAM operations
@@ -413,6 +429,87 @@ enum Commands {
         #[arg(long, value_name = "N", default_value = "512")]
         max_starts: usize,
     },
+
+    /// Compute between-sample scaling factors from BAM files.
+    #[command(
+        name = "bam-normalize",
+        visible_alias = "norm-factors",
+        after_help = "Example:\n  bamnado bam-normalize -b chip1.bam -b chip2.bam \\\n    --method csaw-background --bin-size 10000 --blacklist blacklist.bed"
+    )]
+    BamNormalize {
+        /// Input BAM files. Repeat the flag for each sample.
+        #[arg(short, long, value_name = "BAM")]
+        bams: Vec<PathBuf>,
+
+        /// CSV sample sheet with `sample` and `bam` columns. Alternative to --bams.
+        #[arg(long, value_name = "CSV")]
+        sample_sheet: Option<PathBuf>,
+
+        /// Normalization method.
+        #[arg(
+            short,
+            long,
+            value_enum,
+            default_value = "csaw-background",
+            value_name = "METHOD"
+        )]
+        method: bamnado::normalization_factors::NormFactorMethod,
+
+        /// Bin size for background windows.
+        #[arg(short = 's', long, default_value = "10000", value_name = "BP")]
+        bin_size: u64,
+
+        /// Drop this percentage of highest-count bins before estimating (likely enriched).
+        #[arg(long, default_value = "5.0", value_name = "PCT")]
+        exclude_top_percent: f64,
+
+        /// Sample name to use as the TMM reference. Defaults to the library size closest to the geometric mean.
+        #[arg(long, value_name = "NAME")]
+        reference_sample: Option<String>,
+
+        /// TMM trim fraction for M-values.
+        #[arg(long, default_value = "0.3", value_name = "FRACTION")]
+        logratio_trim: f64,
+
+        /// TMM trim fraction for A-values.
+        #[arg(long, default_value = "0.05", value_name = "FRACTION")]
+        sum_trim: f64,
+
+        /// Reference-name prefix identifying spike-in sequences (--method spike-in).
+        #[arg(short, long, value_name = "PREFIX")]
+        exogenous_prefix: Option<String>,
+
+        /// Count fragments instead of individual read alignments.
+        #[arg(
+            long = "fragment-counts",
+            visible_alias = "use-fragment",
+            action = clap::ArgAction::SetTrue
+        )]
+        use_fragment: bool,
+
+        /// Skip scaffold or unplaced chromosomes.
+        #[arg(
+            long = "ignore-scaffolds",
+            visible_alias = "ignore-scaffold",
+            action = clap::ArgAction::SetTrue
+        )]
+        ignore_scaffold: bool,
+
+        /// Write the bin count matrix to this TSV for QC (e.g. M-A plots).
+        #[arg(long, value_name = "TSV")]
+        counts_out: Option<PathBuf>,
+
+        /// Output format.
+        #[arg(long, value_enum, default_value = "table")]
+        format: NormalizeFormat,
+
+        /// Write output to FILE instead of stdout.
+        #[arg(short, long, value_name = "FILE")]
+        output: Option<PathBuf>,
+
+        #[command(flatten)]
+        filter_options: FilterOptions,
+    },
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -420,6 +517,44 @@ enum InferScaleFormat {
     Table,
     Tsv,
     Json,
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+enum NormalizeFormat {
+    Table,
+    Tsv,
+    Json,
+}
+
+/// Read a CSV sample sheet with `sample` and `bam` columns.
+fn read_sample_sheet(path: &Path) -> Result<(Vec<PathBuf>, Vec<String>)> {
+    let df = CsvReadOptions::default()
+        .with_has_header(true)
+        .try_into_reader_with_file_path(Some(path.to_path_buf()))?
+        .finish()
+        .context("Failed to read sample sheet")?;
+
+    let sample_col = df
+        .column("sample")
+        .context("Missing 'sample' column in sample sheet")?
+        .str()
+        .context("'sample' column is not string type")?;
+    let bam_col = df
+        .column("bam")
+        .context("Missing 'bam' column in sample sheet")?
+        .str()
+        .context("'bam' column is not string type")?;
+
+    let mut samples = Vec::new();
+    let mut bams = Vec::new();
+    for (sample, bam) in sample_col.into_iter().zip(bam_col) {
+        let sample = sample.ok_or_else(|| anyhow::anyhow!("Null value in 'sample' column"))?;
+        let bam = bam.ok_or_else(|| anyhow::anyhow!("Null value in 'bam' column"))?;
+        samples.push(sample.to_string());
+        bams.push(PathBuf::from(bam));
+    }
+
+    Ok((bams, samples))
 }
 
 // Helper functions to reduce code duplication
@@ -490,6 +625,15 @@ fn log_active_filters(filter_options: &FilterOptions) {
     if let Some(tag) = &filter_options.filter_tag {
         let value = filter_options.filter_tag_value.as_deref().unwrap_or("*");
         rows.push(("tag", format!("{tag}={value}")));
+    }
+    if filter_options.ignore_duplicates {
+        rows.push(("duplicates", "excluded".to_string()));
+    }
+    if filter_options.ignore_secondary {
+        rows.push(("secondary alignments", "excluded".to_string()));
+    }
+    if filter_options.ignore_supplementary {
+        rows.push(("supplementary alignments", "excluded".to_string()));
     }
 
     let mut table = Table::new();
@@ -577,7 +721,10 @@ fn create_filter_from_options(
         filter_options.filter_tag_value.clone(),
         filter_options.min_fragment_length,
         filter_options.max_fragment_length,
-    ))
+    )
+    .with_exclude_duplicates(filter_options.ignore_duplicates)
+    .with_exclude_secondary(filter_options.ignore_secondary)
+    .with_exclude_supplementary(filter_options.ignore_supplementary))
 }
 
 fn process_output_file_type(output: &Path) -> Result<FileType> {
@@ -750,7 +897,10 @@ fn main() -> Result<()> {
                     filter_options.filter_tag_value.clone(),
                     filter_options.min_fragment_length,
                     filter_options.max_fragment_length,
-                );
+                )
+                .with_exclude_duplicates(filter_options.ignore_duplicates)
+                .with_exclude_secondary(filter_options.ignore_secondary)
+                .with_exclude_supplementary(filter_options.ignore_supplementary);
 
                 // Create pileup
                 pileups.push(bamnado::coverage_analysis::BamPileup::new(
@@ -1163,6 +1313,221 @@ fn main() -> Result<()> {
                     }
                 }
                 InferScaleFormat::Json => {
+                    buf = serde_json::to_string_pretty(&result)?;
+                    buf.push('\n');
+                }
+            }
+
+            match output {
+                Some(path) => std::fs::write(path, &buf)
+                    .with_context(|| format!("Cannot write to {}", path.display()))?,
+                None => print!("{buf}"),
+            }
+        }
+
+        Commands::BamNormalize {
+            bams,
+            sample_sheet,
+            method,
+            bin_size,
+            exclude_top_percent,
+            reference_sample,
+            logratio_trim,
+            sum_trim,
+            exogenous_prefix,
+            use_fragment,
+            ignore_scaffold,
+            counts_out,
+            format,
+            output,
+            filter_options,
+        } => {
+            use bamnado::normalization_factors::NormFactorMethod;
+
+            let (bam_paths, sample_names) = match (sample_sheet, bams.is_empty()) {
+                (Some(sheet), true) => read_sample_sheet(sheet)?,
+                (None, false) => {
+                    let mut names: Vec<String> = bams
+                        .iter()
+                        .map(|b| {
+                            b.file_stem()
+                                .and_then(|s| s.to_str())
+                                .map(String::from)
+                                .unwrap_or_else(|| b.display().to_string())
+                        })
+                        .collect();
+
+                    // Disambiguate duplicate sample names (e.g. the same BAM passed twice)
+                    // so per-sample columns/labels stay unique downstream.
+                    let mut occurrences: std::collections::HashMap<String, usize> =
+                        std::collections::HashMap::new();
+                    for name in &names {
+                        *occurrences.entry(name.clone()).or_insert(0) += 1;
+                    }
+                    if occurrences.values().any(|&count| count > 1) {
+                        let mut seen_so_far: std::collections::HashMap<String, usize> =
+                            std::collections::HashMap::new();
+                        for name in names.iter_mut() {
+                            let total = occurrences[name.as_str()];
+                            let seen = seen_so_far.entry(name.clone()).or_insert(0);
+                            *seen += 1;
+                            if total > 1 {
+                                *name = format!("{name}_{seen}");
+                            }
+                        }
+                    }
+
+                    (bams.clone(), names)
+                }
+                (Some(_), false) => {
+                    return Err(anyhow::anyhow!(
+                        "Provide either --bams or --sample-sheet, not both"
+                    ));
+                }
+                (None, true) => {
+                    return Err(anyhow::anyhow!("Provide either --bams or --sample-sheet"));
+                }
+            };
+
+            let min_samples = match method {
+                NormFactorMethod::Tmm
+                | NormFactorMethod::CsawBackground
+                | NormFactorMethod::MedianOfRatios => 2,
+                NormFactorMethod::Cpm | NormFactorMethod::SpikeIn => 1,
+            };
+            anyhow::ensure!(
+                bam_paths.len() >= min_samples,
+                "{method:?} requires at least {min_samples} sample(s), got {}",
+                bam_paths.len()
+            );
+
+            for bam in &bam_paths {
+                validate_bam_file(bam)?;
+            }
+
+            log_active_filters(filter_options);
+
+            let bam_stats: Vec<bamnado::BamStats> = bam_paths
+                .iter()
+                .map(|p| {
+                    bamnado::BamStats::new(p.clone())
+                        .with_context(|| format!("Failed to read BAM stats for {}", p.display()))
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let filters: Vec<bamnado::read_filter::BamReadFilter> = bam_stats
+                .iter()
+                .map(|stats| create_filter_from_options(filter_options, Some(stats)))
+                .collect::<Result<Vec<_>>>()?;
+
+            let result = if matches!(method, NormFactorMethod::SpikeIn) {
+                let prefix = exogenous_prefix.clone().ok_or_else(|| {
+                    anyhow::anyhow!("--exogenous-prefix is required for --method spike-in")
+                })?;
+                bamnado::normalization_factors::spike_in_scale_factors(
+                    &bam_stats,
+                    &sample_names,
+                    &prefix,
+                )
+                .context("Failed to compute spike-in scale factors")?
+            } else {
+                let counts = bamnado::bin_counts::count_bins(
+                    &bam_paths,
+                    &sample_names,
+                    *bin_size,
+                    &filters,
+                    *use_fragment,
+                    *ignore_scaffold,
+                )
+                .context("Failed to count reads per bin")?;
+
+                if let Some(counts_out_path) = counts_out {
+                    let mut df = counts.to_polars()?;
+                    let mut file = std::fs::File::create(counts_out_path)
+                        .context("Failed to create --counts-out file")?;
+                    CsvWriter::new(&mut file)
+                        .include_header(true)
+                        .with_separator(b'\t')
+                        .finish(&mut df)?;
+                }
+
+                let params = bamnado::normalization_factors::NormFactorParams {
+                    reference_sample: reference_sample.clone(),
+                    logratio_trim: *logratio_trim,
+                    sum_trim: *sum_trim,
+                    exclude_top_percent: *exclude_top_percent,
+                    ..Default::default()
+                };
+
+                bamnado::normalization_factors::compute_scale_factors(&counts, method, &params)
+                    .context("Failed to compute scale factors")?
+            };
+
+            let mut buf = String::new();
+            match format {
+                NormalizeFormat::Table => {
+                    let mut table = Table::new();
+                    table
+                        .load_preset(UTF8_FULL)
+                        .apply_modifier(UTF8_ROUND_CORNERS)
+                        .set_content_arrangement(ContentArrangement::Dynamic)
+                        .set_header(vec![
+                            "sample",
+                            "library_size",
+                            "norm_factor",
+                            "scale_factor",
+                            "reference",
+                        ]);
+
+                    for i in 0..result.sample_names.len() {
+                        let is_ref = result.reference_sample.as_deref()
+                            == Some(result.sample_names[i].as_str());
+                        table.add_row(vec![
+                            Cell::new(&result.sample_names[i]),
+                            Cell::new(result.library_sizes[i].to_string())
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format!("{:.6}", result.norm_factors[i]))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(format!("{:.6}", result.scale_factors[i]))
+                                .set_alignment(CellAlignment::Right),
+                            Cell::new(if is_ref { "yes" } else { "-" })
+                                .set_alignment(CellAlignment::Right),
+                        ]);
+                    }
+
+                    use std::fmt::Write as _;
+                    writeln!(buf, "{table}").unwrap();
+                    writeln!(buf, "method: {}", result.method).unwrap();
+                    writeln!(
+                        buf,
+                        "bins: {} used / {} total",
+                        result.n_bins_used, result.n_bins_total
+                    )
+                    .unwrap();
+                }
+                NormalizeFormat::Tsv => {
+                    use std::fmt::Write as _;
+                    writeln!(
+                        buf,
+                        "sample\tlibrary_size\tnorm_factor\tscale_factor\treference"
+                    )
+                    .unwrap();
+                    for i in 0..result.sample_names.len() {
+                        let is_ref = result.reference_sample.as_deref()
+                            == Some(result.sample_names[i].as_str());
+                        writeln!(
+                            buf,
+                            "{}\t{}\t{:.6}\t{:.6}\t{}",
+                            result.sample_names[i],
+                            result.library_sizes[i],
+                            result.norm_factors[i],
+                            result.scale_factors[i],
+                            if is_ref { "yes" } else { "-" }
+                        )
+                        .unwrap();
+                    }
+                }
+                NormalizeFormat::Json => {
                     buf = serde_json::to_string_pretty(&result)?;
                     buf.push('\n');
                 }

--- a/bamnado/src/normalization_factors.rs
+++ b/bamnado/src/normalization_factors.rs
@@ -1,0 +1,819 @@
+//! # Normalization Factors Module
+//!
+//! This module estimates between-sample scaling factors from a shared genomic bin count
+//! matrix (see `bin_counts`). It supports:
+//! *   **TMM** (trimmed mean of M-values), matching `edgeR::calcNormFactors(method = "TMM")`.
+//! *   **csaw-background**, TMM restricted to large background bins with the most-enriched
+//!     bins excluded, matching the `csaw` composition-bias workflow.
+//! *   **CPM**, a naive total-count baseline for comparison.
+//! *   **Median-of-ratios** (DESeq2-style), a robust alternative estimator.
+//! *   **Spike-in**, using exogenous mapped-read counts read directly from the BAM index.
+//!
+//! ## Scale factor definition
+//!
+//! For the bin-count-based methods (TMM, csaw-background, median-of-ratios), each sample's
+//! *effective library size* is `E_j = N_j * f_j`, where `N_j` is the sample's post-filter
+//! library size and `f_j` is the method's composition-bias norm factor (geometric-mean
+//! centred so that `prod(f_j) == 1`). The reported `scale_factor_j` is
+//! `geometric_mean(E) / E_j`, so factors are centred on 1 and only relative depth /
+//! composition differences move a sample's factor away from 1. `CPM` is a special case:
+//! `scale_factor_j = 1e6 / N_j`, matching [`crate::signal_normalization::NormalizationMethod::CPM`].
+//!
+//! Apply the reported `scale_factors` directly to `bam-coverage -f` / `bigwig-aggregate
+//! --scale-factors`.
+
+use std::collections::HashSet;
+
+use anyhow::{Context, Result, bail};
+use ndarray::Array2;
+use serde::Serialize;
+
+use crate::bam_utils::BamStats;
+use crate::bin_counts::BinCounts;
+
+/// Between-sample normalization methods.
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum NormFactorMethod {
+    /// Trimmed mean of M-values (edgeR `calcNormFactors(method = "TMM")`).
+    Tmm,
+    /// TMM restricted to large background bins with the most-enriched bins excluded (csaw-style).
+    CsawBackground,
+    /// Counts per million mapped reads — a naive depth-only baseline.
+    Cpm,
+    /// DESeq2-style median-of-ratios estimator.
+    MedianOfRatios,
+    /// Spike-in (exogenous) mapped-read count ratio, read from the BAM index.
+    SpikeIn,
+}
+
+/// Tuning parameters shared across the bin-count-based estimators.
+#[derive(Debug, Clone)]
+pub struct NormFactorParams {
+    /// Sample to use as the TMM reference. `None` picks the sample whose bin total is
+    /// closest to the geometric mean of all bin totals.
+    pub reference_sample: Option<String>,
+    /// Fraction of extreme M-values (log-ratios) trimmed from each tail before averaging.
+    pub logratio_trim: f64,
+    /// Fraction of extreme A-values (log-intensities) trimmed from each tail before averaging.
+    pub sum_trim: f64,
+    /// Minimum A-value (log-intensity) for a bin to be considered; matches edgeR's `Acutoff`.
+    pub a_cutoff: f64,
+    /// Weight M-values by their estimated asymptotic variance (edgeR's default behaviour).
+    pub do_weighting: bool,
+    /// Percentage of highest-mean-count bins dropped before estimating (csaw-background only).
+    pub exclude_top_percent: f64,
+}
+
+impl Default for NormFactorParams {
+    fn default() -> Self {
+        Self {
+            reference_sample: None,
+            logratio_trim: 0.30,
+            sum_trim: 0.05,
+            a_cutoff: -1e10,
+            do_weighting: true,
+            exclude_top_percent: 5.0,
+        }
+    }
+}
+
+/// The result of a between-sample scaling factor computation.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScaleFactors {
+    /// Name of the method used to compute these factors.
+    pub method: String,
+    /// Sample names, in the same order as the other per-sample fields.
+    pub sample_names: Vec<String>,
+    /// Post-filter library size (or mapped-read count, for spike-in) per sample.
+    pub library_sizes: Vec<u64>,
+    /// Method-specific composition-bias factor per sample (geometric-mean centred to 1
+    /// where applicable).
+    pub norm_factors: Vec<f64>,
+    /// Multiplier to pass to `bam-coverage -f` / `bigwig-aggregate --scale-factors`.
+    pub scale_factors: Vec<f64>,
+    /// The sample used as the TMM reference, if applicable.
+    pub reference_sample: Option<String>,
+    /// Total number of bins in the input count matrix.
+    pub n_bins_total: usize,
+    /// Number of bins actually used by the estimator (after any pre-filtering).
+    pub n_bins_used: usize,
+}
+
+/// A pluggable between-sample scaling factor estimation strategy.
+///
+/// New methods implement this trait without changing any call sites.
+pub trait NormFactorEstimator {
+    /// Short, stable name for this method (used in [`ScaleFactors::method`]).
+    fn name(&self) -> &'static str;
+
+    /// Estimate scaling factors from a shared bin count matrix.
+    fn estimate(&self, counts: &BinCounts, params: &NormFactorParams) -> Result<ScaleFactors>;
+}
+
+fn geometric_mean(xs: &[f64]) -> f64 {
+    let logs: Vec<f64> = xs
+        .iter()
+        .filter(|&&x| x > 0.0 && x.is_finite())
+        .map(|&x| x.ln())
+        .collect();
+    if logs.is_empty() {
+        1.0
+    } else {
+        (logs.iter().sum::<f64>() / logs.len() as f64).exp()
+    }
+}
+
+fn median(xs: &[f64]) -> f64 {
+    let mut v: Vec<f64> = xs.to_vec();
+    v.sort_by(|a, b| a.partial_cmp(b).expect("NaN in median input"));
+    let n = v.len();
+    if n == 0 {
+        return f64::NAN;
+    }
+    if n % 2 == 1 {
+        v[n / 2]
+    } else {
+        (v[n / 2 - 1] + v[n / 2]) / 2.0
+    }
+}
+
+/// Centre effective library sizes into scale factors: `geometric_mean(E) / E_j`.
+fn centred_scale_factors(effective_library_sizes: &[f64]) -> Vec<f64> {
+    let gm = geometric_mean(effective_library_sizes);
+    effective_library_sizes
+        .iter()
+        .map(|&e| if e > 0.0 { gm / e } else { 1.0 })
+        .collect()
+}
+
+/// Trimmed mean of M-values (edgeR `calcNormFactors(method = "TMM")`).
+pub struct Tmm;
+
+impl Tmm {
+    /// Compute the pairwise TMM factor of sample `j` against reference sample `r`.
+    ///
+    /// Implements edgeR's rank-based double trim (ties broken by first occurrence, i.e.
+    /// edgeR's `ties = "first"`), which is the one place a naive value-based trim
+    /// implementation would diverge from R.
+    fn pairwise_factor(
+        &self,
+        counts: &BinCounts,
+        j: usize,
+        r: usize,
+        n_j: f64,
+        n_r: f64,
+        params: &NormFactorParams,
+    ) -> f64 {
+        let mut m = Vec::new();
+        let mut a = Vec::new();
+        let mut v = Vec::new();
+
+        for i in 0..counts.bins.len() {
+            let y_j = counts.counts[[i, j]] as f64;
+            let y_r = counts.counts[[i, r]] as f64;
+            if y_j <= 0.0 || y_r <= 0.0 {
+                continue;
+            }
+            let m_g = ((y_j / n_j) / (y_r / n_r)).log2();
+            let a_g = 0.5 * ((y_j / n_j) * (y_r / n_r)).log2();
+            if !m_g.is_finite() || !a_g.is_finite() {
+                continue;
+            }
+            if a_g <= params.a_cutoff {
+                continue;
+            }
+            let v_g = (n_j - y_j) / (n_j * y_j) + (n_r - y_r) / (n_r * y_r);
+            m.push(m_g);
+            a.push(a_g);
+            v.push(v_g);
+        }
+
+        if m.is_empty() {
+            return 1.0;
+        }
+
+        let max_abs_m = m.iter().fold(0.0_f64, |acc, &x| acc.max(x.abs()));
+        if max_abs_m < 1e-6 {
+            return 1.0;
+        }
+
+        let n = m.len();
+        let mut order_m: Vec<usize> = (0..n).collect();
+        order_m.sort_by(|&x, &y| m[x].partial_cmp(&m[y]).unwrap());
+        let mut rank_m = vec![0usize; n];
+        for (rank, &idx) in order_m.iter().enumerate() {
+            rank_m[idx] = rank;
+        }
+
+        let mut order_a: Vec<usize> = (0..n).collect();
+        order_a.sort_by(|&x, &y| a[x].partial_cmp(&a[y]).unwrap());
+        let mut rank_a = vec![0usize; n];
+        for (rank, &idx) in order_a.iter().enumerate() {
+            rank_a[idx] = rank;
+        }
+
+        // edgeR uses 1-based ranks: loL = floor(n*trim)+1; hiL = n+1-loL.
+        let lo_l = ((n as f64 * params.logratio_trim).floor() as usize) + 1;
+        let hi_l = n + 1 - lo_l;
+        let lo_s = ((n as f64 * params.sum_trim).floor() as usize) + 1;
+        let hi_s = n + 1 - lo_s;
+
+        let mut sum_wm = 0.0;
+        let mut sum_w = 0.0;
+        let mut kept_m = Vec::new();
+
+        for g in 0..n {
+            let rm1 = rank_m[g] + 1;
+            let ra1 = rank_a[g] + 1;
+            if rm1 < lo_l || rm1 > hi_l || ra1 < lo_s || ra1 > hi_s {
+                continue;
+            }
+            kept_m.push(m[g]);
+            if params.do_weighting {
+                let w = 1.0 / v[g];
+                sum_wm += w * m[g];
+                sum_w += w;
+            }
+        }
+
+        let f = if kept_m.is_empty() {
+            0.0
+        } else if params.do_weighting {
+            if sum_w > 0.0 { sum_wm / sum_w } else { 0.0 }
+        } else {
+            kept_m.iter().sum::<f64>() / kept_m.len() as f64
+        };
+
+        let f = if f.is_nan() { 0.0 } else { f };
+        2f64.powf(f)
+    }
+}
+
+impl NormFactorEstimator for Tmm {
+    fn name(&self) -> &'static str {
+        "tmm"
+    }
+
+    fn estimate(&self, counts: &BinCounts, params: &NormFactorParams) -> Result<ScaleFactors> {
+        let n_samples = counts.sample_names.len();
+        anyhow::ensure!(
+            n_samples >= 2,
+            "TMM requires at least 2 samples, got {n_samples}"
+        );
+
+        // N_j = colSums(counts) -- bin totals, matching edgeR (not post-filter library size).
+        let bin_totals: Vec<f64> = (0..n_samples)
+            .map(|j| {
+                (0..counts.bins.len())
+                    .map(|i| counts.counts[[i, j]] as f64)
+                    .sum()
+            })
+            .collect();
+
+        let ref_idx = match &params.reference_sample {
+            Some(name) => counts
+                .sample_names
+                .iter()
+                .position(|n| n == name)
+                .ok_or_else(|| anyhow::anyhow!("Unknown TMM reference sample: {name}"))?,
+            None => {
+                let target = geometric_mean(&bin_totals);
+                bin_totals
+                    .iter()
+                    .enumerate()
+                    .min_by(|(_, a), (_, b)| {
+                        (*a - target)
+                            .abs()
+                            .partial_cmp(&(*b - target).abs())
+                            .unwrap()
+                    })
+                    .map(|(i, _)| i)
+                    .unwrap_or(0)
+            }
+        };
+
+        let mut norm_factors = vec![1.0f64; n_samples];
+        for j in 0..n_samples {
+            if j == ref_idx {
+                continue;
+            }
+            norm_factors[j] = self.pairwise_factor(
+                counts,
+                j,
+                ref_idx,
+                bin_totals[j],
+                bin_totals[ref_idx],
+                params,
+            );
+        }
+
+        // Centre so the geometric mean of norm_factors is 1.
+        let gm = geometric_mean(&norm_factors);
+        for f in norm_factors.iter_mut() {
+            *f /= gm;
+        }
+
+        let effective_library_sizes: Vec<f64> = counts
+            .library_sizes
+            .iter()
+            .zip(norm_factors.iter())
+            .map(|(&lib, &f)| lib as f64 * f)
+            .collect();
+        let scale_factors = centred_scale_factors(&effective_library_sizes);
+
+        Ok(ScaleFactors {
+            method: self.name().to_string(),
+            sample_names: counts.sample_names.clone(),
+            library_sizes: counts.library_sizes.clone(),
+            norm_factors,
+            scale_factors,
+            reference_sample: Some(counts.sample_names[ref_idx].clone()),
+            n_bins_total: counts.bins.len(),
+            n_bins_used: counts.bins.len(),
+        })
+    }
+}
+
+/// TMM restricted to large background bins, with the most-enriched bins excluded.
+///
+/// Blacklist exclusion happens upstream (via `--blacklist` on the read filter, which zeroes
+/// out those bins before they ever reach this estimator). This estimator additionally drops
+/// the top `exclude_top_percent` of bins by mean count (likely enriched / peak bins) and any
+/// all-zero bins, then delegates to `inner` (TMM by default).
+pub struct CsawBackground {
+    /// The estimator applied to the filtered background bins.
+    pub inner: Box<dyn NormFactorEstimator>,
+}
+
+impl Default for CsawBackground {
+    fn default() -> Self {
+        Self {
+            inner: Box::new(Tmm),
+        }
+    }
+}
+
+impl NormFactorEstimator for CsawBackground {
+    fn name(&self) -> &'static str {
+        "csaw-background"
+    }
+
+    fn estimate(&self, counts: &BinCounts, params: &NormFactorParams) -> Result<ScaleFactors> {
+        let n_bins_total = counts.bins.len();
+        let n_samples = counts.sample_names.len();
+
+        let mut mean_counts: Vec<(usize, f64)> = (0..n_bins_total)
+            .map(|i| {
+                let mean = (0..n_samples)
+                    .map(|j| counts.counts[[i, j]] as f64)
+                    .sum::<f64>()
+                    / n_samples as f64;
+                (i, mean)
+            })
+            .collect();
+
+        let n_exclude =
+            ((n_bins_total as f64) * (params.exclude_top_percent / 100.0)).round() as usize;
+        mean_counts.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        let excluded: HashSet<usize> = mean_counts
+            .iter()
+            .take(n_exclude.min(n_bins_total))
+            .map(|(i, _)| *i)
+            .collect();
+
+        let mut keep_rows = Vec::new();
+        let mut keep_bins = Vec::new();
+        for i in 0..n_bins_total {
+            if excluded.contains(&i) {
+                continue;
+            }
+            let all_zero = (0..n_samples).all(|j| counts.counts[[i, j]] == 0);
+            if all_zero {
+                continue;
+            }
+            keep_rows.push(i);
+            keep_bins.push(counts.bins[i].clone());
+        }
+
+        anyhow::ensure!(
+            !keep_rows.is_empty(),
+            "csaw-background: no bins remain after excluding the top {}% and all-zero bins",
+            params.exclude_top_percent
+        );
+
+        let mut filtered_counts = Array2::<u64>::zeros((keep_rows.len(), n_samples));
+        for (new_i, &old_i) in keep_rows.iter().enumerate() {
+            for j in 0..n_samples {
+                filtered_counts[[new_i, j]] = counts.counts[[old_i, j]];
+            }
+        }
+
+        let filtered = BinCounts {
+            sample_names: counts.sample_names.clone(),
+            bin_size: counts.bin_size,
+            bins: keep_bins,
+            counts: filtered_counts,
+            library_sizes: counts.library_sizes.clone(),
+        };
+
+        let mut result = self
+            .inner
+            .estimate(&filtered, params)
+            .context("csaw-background: inner estimator failed")?;
+        result.method = self.name().to_string();
+        result.n_bins_total = n_bins_total;
+        result.n_bins_used = keep_rows.len();
+        Ok(result)
+    }
+}
+
+/// Counts per million mapped reads — a naive depth-only baseline for comparison.
+///
+/// Matches [`crate::signal_normalization::NormalizationMethod::CPM`]: `scale_factor_j = 1e6 /
+/// library_size_j`. `norm_factors` are trivially 1.0 (no composition-bias correction).
+pub struct Cpm;
+
+impl NormFactorEstimator for Cpm {
+    fn name(&self) -> &'static str {
+        "cpm"
+    }
+
+    fn estimate(&self, counts: &BinCounts, _params: &NormFactorParams) -> Result<ScaleFactors> {
+        let n_samples = counts.sample_names.len();
+        let norm_factors = vec![1.0; n_samples];
+        let scale_factors: Vec<f64> = counts
+            .library_sizes
+            .iter()
+            .map(|&lib| if lib == 0 { 0.0 } else { 1e6 / lib as f64 })
+            .collect();
+
+        Ok(ScaleFactors {
+            method: self.name().to_string(),
+            sample_names: counts.sample_names.clone(),
+            library_sizes: counts.library_sizes.clone(),
+            norm_factors,
+            scale_factors,
+            reference_sample: None,
+            n_bins_total: counts.bins.len(),
+            n_bins_used: counts.bins.len(),
+        })
+    }
+}
+
+/// DESeq2-style median-of-ratios estimator.
+///
+/// Uses bins where all samples have a nonzero count: `gm_g = exp(mean_j(ln y_gj))`,
+/// `s_j = median_g(y_gj / gm_g)`, `scale_factor_j = median(s) / s_j`.
+pub struct MedianOfRatios;
+
+impl NormFactorEstimator for MedianOfRatios {
+    fn name(&self) -> &'static str {
+        "median-of-ratios"
+    }
+
+    fn estimate(&self, counts: &BinCounts, _params: &NormFactorParams) -> Result<ScaleFactors> {
+        let n_samples = counts.sample_names.len();
+        let mut per_sample_ratios: Vec<Vec<f64>> = vec![Vec::new(); n_samples];
+
+        for i in 0..counts.bins.len() {
+            let row: Vec<u64> = (0..n_samples).map(|j| counts.counts[[i, j]]).collect();
+            if row.contains(&0) {
+                continue;
+            }
+            let log_gm = row.iter().map(|&c| (c as f64).ln()).sum::<f64>() / n_samples as f64;
+            let gm = log_gm.exp();
+            if gm <= 0.0 || !gm.is_finite() {
+                continue;
+            }
+            for (j, ratios) in per_sample_ratios.iter_mut().enumerate() {
+                ratios.push(row[j] as f64 / gm);
+            }
+        }
+
+        anyhow::ensure!(
+            !per_sample_ratios[0].is_empty(),
+            "median-of-ratios: no bins with a nonzero count in every sample"
+        );
+
+        let s: Vec<f64> = per_sample_ratios
+            .iter()
+            .map(|ratios| median(ratios))
+            .collect();
+        let median_s = median(&s);
+
+        let scale_factors: Vec<f64> = s
+            .iter()
+            .map(|&sj| if sj > 0.0 { median_s / sj } else { 1.0 })
+            .collect();
+        let norm_factors: Vec<f64> = s
+            .iter()
+            .map(|&sj| if median_s > 0.0 { sj / median_s } else { 1.0 })
+            .collect();
+
+        Ok(ScaleFactors {
+            method: self.name().to_string(),
+            sample_names: counts.sample_names.clone(),
+            library_sizes: counts.library_sizes.clone(),
+            norm_factors,
+            scale_factors,
+            reference_sample: None,
+            n_bins_total: counts.bins.len(),
+            n_bins_used: per_sample_ratios[0].len(),
+        })
+    }
+}
+
+/// Return the estimator implementation for a bin-count-based [`NormFactorMethod`].
+///
+/// # Errors
+///
+/// Returns an error for [`NormFactorMethod::SpikeIn`], which does not use the bin count
+/// matrix at all — use [`spike_in_scale_factors`] instead.
+pub fn estimator_for(method: &NormFactorMethod) -> Result<Box<dyn NormFactorEstimator>> {
+    Ok(match method {
+        NormFactorMethod::Tmm => Box::new(Tmm),
+        NormFactorMethod::CsawBackground => Box::new(CsawBackground::default()),
+        NormFactorMethod::Cpm => Box::new(Cpm),
+        NormFactorMethod::MedianOfRatios => Box::new(MedianOfRatios),
+        NormFactorMethod::SpikeIn => bail!(
+            "SpikeIn normalization does not use the bin count matrix; call \
+             `spike_in_scale_factors` with per-sample BamStats and an exogenous-name prefix \
+             instead."
+        ),
+    })
+}
+
+/// Compute between-sample scaling factors from a shared bin count matrix.
+///
+/// # Arguments
+///
+/// * `counts` - The shared sample × bin count matrix (see `bin_counts::count_bins`).
+/// * `method` - The normalization method to use. Must not be [`NormFactorMethod::SpikeIn`]
+///   (use [`spike_in_scale_factors`] for that method instead).
+/// * `params` - Tuning parameters for the bin-count-based estimators.
+pub fn compute_scale_factors(
+    counts: &BinCounts,
+    method: &NormFactorMethod,
+    params: &NormFactorParams,
+) -> Result<ScaleFactors> {
+    estimator_for(method)?.estimate(counts, params)
+}
+
+/// Compute between-sample scaling factors from spike-in (exogenous) mapped-read counts.
+///
+/// Counts come directly from each BAM's index (`BamStats::mapped_reads_by_prefix`) — no BAM
+/// record scan, and no read filtering (MAPQ, duplicates, etc. is not applied). This is the
+/// same basis as `BamStats::n_mapped` and the existing `SplitStats::spikein_norm_factor`.
+///
+/// # Arguments
+///
+/// * `bam_stats` - Per-sample `BamStats`, same length and order as `sample_names`.
+/// * `sample_names` - Sample names.
+/// * `exogenous_prefix` - Reference-name prefix identifying spike-in sequences.
+pub fn spike_in_scale_factors(
+    bam_stats: &[BamStats],
+    sample_names: &[String],
+    exogenous_prefix: &str,
+) -> Result<ScaleFactors> {
+    anyhow::ensure!(
+        !bam_stats.is_empty(),
+        "At least one BAM file is required for spike-in normalization"
+    );
+    anyhow::ensure!(
+        bam_stats.len() == sample_names.len(),
+        "Number of BAM stats ({}) does not match number of sample names ({})",
+        bam_stats.len(),
+        sample_names.len()
+    );
+
+    let exogenous_counts: Vec<u64> = bam_stats
+        .iter()
+        .map(|stats| stats.mapped_reads_by_prefix(exogenous_prefix).0)
+        .collect();
+
+    for (name, &count) in sample_names.iter().zip(exogenous_counts.iter()) {
+        anyhow::ensure!(
+            count > 0,
+            "Sample '{name}' has zero reads mapped to references with prefix '{exogenous_prefix}'"
+        );
+    }
+
+    let exogenous_f: Vec<f64> = exogenous_counts.iter().map(|&c| c as f64).collect();
+    let gm = geometric_mean(&exogenous_f);
+    let scale_factors: Vec<f64> = exogenous_f.iter().map(|&c| gm / c).collect();
+    let norm_factors: Vec<f64> = exogenous_f.iter().map(|&c| c / gm).collect();
+    let library_sizes: Vec<u64> = bam_stats.iter().map(|stats| stats.n_mapped()).collect();
+
+    Ok(ScaleFactors {
+        method: "spike-in".to_string(),
+        sample_names: sample_names.to_vec(),
+        library_sizes,
+        norm_factors,
+        scale_factors,
+        reference_sample: None,
+        n_bins_total: 0,
+        n_bins_used: 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bin_counts::BinRegion;
+
+    fn make_bins(n: usize) -> Vec<BinRegion> {
+        (0..n)
+            .map(|i| BinRegion {
+                chrom: "chr1".to_string(),
+                start: (i * 1000 + 1) as u64,
+                end: ((i + 1) * 1000) as u64,
+            })
+            .collect()
+    }
+
+    fn make_counts(
+        sample_names: Vec<&str>,
+        library_sizes: Vec<u64>,
+        rows: Vec<Vec<u64>>,
+    ) -> BinCounts {
+        let n_bins = rows.len();
+        let n_samples = sample_names.len();
+        let mut counts = Array2::<u64>::zeros((n_bins, n_samples));
+        for (i, row) in rows.iter().enumerate() {
+            for (j, &v) in row.iter().enumerate() {
+                counts[[i, j]] = v;
+            }
+        }
+        BinCounts {
+            sample_names: sample_names.into_iter().map(String::from).collect(),
+            bin_size: 1000,
+            bins: make_bins(n_bins),
+            counts,
+            library_sizes,
+        }
+    }
+
+    #[test]
+    fn test_tmm_identical_samples_gives_factor_one() {
+        let rows: Vec<Vec<u64>> = (0..20).map(|i| vec![10 + i, 10 + i, 10 + i]).collect();
+        let counts = make_counts(vec!["a", "b", "c"], vec![1000, 1000, 1000], rows);
+
+        let result = compute_scale_factors(
+            &counts,
+            &NormFactorMethod::Tmm,
+            &NormFactorParams::default(),
+        )
+        .expect("TMM failed");
+
+        for &f in &result.norm_factors {
+            assert!((f - 1.0).abs() < 1e-9, "norm_factor {f} not ~1.0");
+        }
+        for &f in &result.scale_factors {
+            assert!((f - 1.0).abs() < 1e-9, "scale_factor {f} not ~1.0");
+        }
+    }
+
+    #[test]
+    fn test_tmm_prod_norm_factors_is_one() {
+        // Sample b has a handful of bins massively inflated (composition bias); a and c
+        // are otherwise identical background samples.
+        let mut rows: Vec<Vec<u64>> = (0..20).map(|i| vec![50 + i, 50 + i, 50 + i]).collect();
+        for row in rows.iter_mut().take(3) {
+            row[1] *= 50;
+        }
+        let counts = make_counts(vec!["a", "b", "c"], vec![2000, 3500, 2000], rows);
+
+        let result = compute_scale_factors(
+            &counts,
+            &NormFactorMethod::Tmm,
+            &NormFactorParams::default(),
+        )
+        .expect("TMM failed");
+
+        let prod: f64 = result.norm_factors.iter().product();
+        assert!((prod - 1.0).abs() < 1e-6, "prod(norm_factors) = {prod}");
+
+        // The unbiased pair (a, c) should end up close to factor 1 relative to each other.
+        let ratio = result.norm_factors[0] / result.norm_factors[2];
+        assert!(
+            (ratio - 1.0).abs() < 0.05,
+            "unbiased pair (a, c) diverged: ratio = {ratio}"
+        );
+    }
+
+    #[test]
+    fn test_tmm_reference_sample_override() {
+        let rows: Vec<Vec<u64>> = (0..20).map(|i| vec![10 + i, 20 + i, 30 + i]).collect();
+        let counts = make_counts(vec!["a", "b", "c"], vec![1000, 2000, 3000], rows);
+
+        let params = NormFactorParams {
+            reference_sample: Some("c".to_string()),
+            ..Default::default()
+        };
+        let result =
+            compute_scale_factors(&counts, &NormFactorMethod::Tmm, &params).expect("TMM failed");
+        assert_eq!(result.reference_sample.as_deref(), Some("c"));
+    }
+
+    #[test]
+    fn test_tmm_unknown_reference_sample_errors() {
+        let rows: Vec<Vec<u64>> = (0..20).map(|i| vec![10 + i, 20 + i]).collect();
+        let counts = make_counts(vec!["a", "b"], vec![1000, 2000], rows);
+
+        let params = NormFactorParams {
+            reference_sample: Some("nonexistent".to_string()),
+            ..Default::default()
+        };
+        let result = compute_scale_factors(&counts, &NormFactorMethod::Tmm, &params);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tmm_single_sample_errors() {
+        let rows: Vec<Vec<u64>> = (0..5).map(|i| vec![10 + i]).collect();
+        let counts = make_counts(vec!["a"], vec![1000], rows);
+        let result = compute_scale_factors(
+            &counts,
+            &NormFactorMethod::Tmm,
+            &NormFactorParams::default(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cpm_trivial() {
+        let rows: Vec<Vec<u64>> = (0..5).map(|i| vec![10 + i, 20 + i]).collect();
+        let counts = make_counts(vec!["a", "b"], vec![1_000_000, 2_000_000], rows);
+        let result = compute_scale_factors(
+            &counts,
+            &NormFactorMethod::Cpm,
+            &NormFactorParams::default(),
+        )
+        .expect("CPM failed");
+        assert_eq!(result.norm_factors, vec![1.0, 1.0]);
+        assert!((result.scale_factors[0] - 1.0).abs() < 1e-9);
+        assert!((result.scale_factors[1] - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_median_of_ratios_known_depth_difference() {
+        // Sample b has exactly 2x the counts of sample a in every bin.
+        let rows: Vec<Vec<u64>> = (0..20).map(|i| vec![100 + i, 2 * (100 + i)]).collect();
+        let counts = make_counts(vec!["a", "b"], vec![10_000, 20_000], rows);
+        let result = compute_scale_factors(
+            &counts,
+            &NormFactorMethod::MedianOfRatios,
+            &NormFactorParams::default(),
+        )
+        .expect("median-of-ratios failed");
+
+        // b is twice as deep as a, so b's scale factor should be half of a's.
+        let ratio = result.scale_factors[1] / result.scale_factors[0];
+        assert!(
+            (ratio - 0.5).abs() < 1e-6,
+            "expected b's scale factor to be half of a's, ratio = {ratio}"
+        );
+    }
+
+    #[test]
+    fn test_csaw_background_excludes_top_bins_and_all_zero_bins() {
+        let mut rows: Vec<Vec<u64>> = (0..20).map(|_| vec![10, 10]).collect();
+        // Two "peak" bins with a huge count, and a couple of all-zero bins.
+        rows[0] = vec![10_000, 10_000];
+        rows[1] = vec![9_000, 9_000];
+        rows[2] = vec![0, 0];
+        rows[3] = vec![0, 0];
+        let counts = make_counts(vec!["a", "b"], vec![1000, 1000], rows);
+
+        let params = NormFactorParams {
+            exclude_top_percent: 10.0,
+            ..Default::default()
+        };
+        let result = compute_scale_factors(&counts, &NormFactorMethod::CsawBackground, &params)
+            .expect("csaw-background failed");
+
+        assert_eq!(result.n_bins_total, 20);
+        // 10% of 20 = 2 excluded as top bins, plus 2 all-zero bins dropped.
+        assert_eq!(result.n_bins_used, 16);
+    }
+
+    #[test]
+    fn test_all_zero_bins_dropped_from_median_of_ratios() {
+        let mut rows: Vec<Vec<u64>> = (0..10).map(|i| vec![10 + i, 10 + i]).collect();
+        rows.push(vec![0, 0]);
+        let counts = make_counts(vec!["a", "b"], vec![1000, 1000], rows);
+        let result = compute_scale_factors(
+            &counts,
+            &NormFactorMethod::MedianOfRatios,
+            &NormFactorParams::default(),
+        )
+        .expect("median-of-ratios failed");
+        assert_eq!(result.n_bins_used, 10);
+    }
+
+    #[test]
+    fn test_estimator_for_spike_in_errors() {
+        let result = estimator_for(&NormFactorMethod::SpikeIn);
+        assert!(result.is_err());
+    }
+}

--- a/bamnado/src/read_filter.rs
+++ b/bamnado/src/read_filter.rs
@@ -49,6 +49,12 @@ pub struct BamReadFilterStats {
     n_failed_tag_filter: AtomicU64,
     // Number of reads filtered by fragment length (insert size / TLEN)
     n_failed_fragment_length: AtomicU64,
+    // Number of reads filtered as PCR/optical duplicates
+    n_failed_duplicate: AtomicU64,
+    // Number of reads filtered as secondary alignments
+    n_failed_secondary: AtomicU64,
+    // Number of reads filtered as supplementary alignments
+    n_failed_supplementary: AtomicU64,
 }
 
 impl Default for BamReadFilterStats {
@@ -71,6 +77,9 @@ impl BamReadFilterStats {
             n_incorrect_strand: AtomicU64::new(0),
             n_failed_tag_filter: AtomicU64::new(0),
             n_failed_fragment_length: AtomicU64::new(0),
+            n_failed_duplicate: AtomicU64::new(0),
+            n_failed_secondary: AtomicU64::new(0),
+            n_failed_supplementary: AtomicU64::new(0),
         }
     }
 
@@ -87,6 +96,9 @@ impl BamReadFilterStats {
             n_incorrect_strand: self.n_incorrect_strand.load(Ordering::Relaxed),
             n_failed_tag_filter: self.n_failed_tag_filter.load(Ordering::Relaxed),
             n_failed_fragment_length: self.n_failed_fragment_length.load(Ordering::Relaxed),
+            n_failed_duplicate: self.n_failed_duplicate.load(Ordering::Relaxed),
+            n_failed_secondary: self.n_failed_secondary.load(Ordering::Relaxed),
+            n_failed_supplementary: self.n_failed_supplementary.load(Ordering::Relaxed),
         }
     }
 }
@@ -104,6 +116,9 @@ pub struct BamReadFilterStatsSnapshot {
     n_incorrect_strand: u64,
     n_failed_tag_filter: u64,
     n_failed_fragment_length: u64,
+    n_failed_duplicate: u64,
+    n_failed_secondary: u64,
+    n_failed_supplementary: u64,
 }
 
 impl Display for BamReadFilterStatsSnapshot {
@@ -180,6 +195,9 @@ impl BamReadFilterStatsSnapshot {
         let mut rows = vec![("Initial reads", remaining, 0, 100.0)];
 
         let failures = [
+            ("Not a duplicate", self.n_failed_duplicate),
+            ("Not secondary", self.n_failed_secondary),
+            ("Not supplementary", self.n_failed_supplementary),
             ("Pass strand filter", self.n_incorrect_strand),
             ("Pass proper-pair filter", self.n_failed_proper_pair),
             ("Pass minimum MAPQ", self.n_failed_mapq),
@@ -218,7 +236,10 @@ impl BamReadFilterStatsSnapshot {
                 + self.n_not_in_read_group
                 + self.n_incorrect_strand
                 + self.n_failed_tag_filter
-                + self.n_failed_fragment_length)
+                + self.n_failed_fragment_length
+                + self.n_failed_duplicate
+                + self.n_failed_secondary
+                + self.n_failed_supplementary)
     }
 
     /// Returns the total number of reads processed.
@@ -270,6 +291,21 @@ impl BamReadFilterStatsSnapshot {
     pub fn n_failed_fragment_length(&self) -> u64 {
         self.n_failed_fragment_length
     }
+
+    /// Returns the number of reads filtered as PCR/optical duplicates.
+    pub fn n_failed_duplicate(&self) -> u64 {
+        self.n_failed_duplicate
+    }
+
+    /// Returns the number of reads filtered as secondary alignments.
+    pub fn n_failed_secondary(&self) -> u64 {
+        self.n_failed_secondary
+    }
+
+    /// Returns the number of reads filtered as supplementary alignments.
+    pub fn n_failed_supplementary(&self) -> u64 {
+        self.n_failed_supplementary
+    }
 }
 
 /// A filter for BAM reads.
@@ -302,6 +338,12 @@ pub struct BamReadFilter {
     min_fragment_length: Option<u32>,
     // Maximum fragment length (template length / insert size)
     max_fragment_length: Option<u32>,
+    // Exclude PCR/optical duplicate reads
+    exclude_duplicates: bool,
+    // Exclude secondary alignments
+    exclude_secondary: bool,
+    // Exclude supplementary alignments
+    exclude_supplementary: bool,
     // Statistics for the filtering process
     stats: Arc<BamReadFilterStats>,
 }
@@ -313,6 +355,9 @@ impl Display for BamReadFilter {
         writeln!(f, "\tMinimum mapping quality: {}", self.min_mapq)?;
         writeln!(f, "\tMinimum read length: {}", self.min_length)?;
         writeln!(f, "\tMaximum read length: {}", self.max_length)?;
+        writeln!(f, "\tExclude duplicates: {}", self.exclude_duplicates)?;
+        writeln!(f, "\tExclude secondary: {}", self.exclude_secondary)?;
+        writeln!(f, "\tExclude supplementary: {}", self.exclude_supplementary)?;
 
         match &self.blacklisted_locations {
             Some(blacklisted_locations) => {
@@ -421,8 +466,104 @@ impl BamReadFilter {
             filter_tag_value,
             min_fragment_length,
             max_fragment_length,
+            exclude_duplicates: false,
+            exclude_secondary: false,
+            exclude_supplementary: false,
             stats: Arc::new(BamReadFilterStats::new()),
         }
+    }
+
+    /// Exclude PCR/optical duplicate reads (SAM flag 0x400).
+    pub fn with_exclude_duplicates(mut self, v: bool) -> Self {
+        self.exclude_duplicates = v;
+        self
+    }
+
+    /// Exclude secondary alignments (SAM flag 0x100).
+    pub fn with_exclude_secondary(mut self, v: bool) -> Self {
+        self.exclude_secondary = v;
+        self
+    }
+
+    /// Exclude supplementary alignments (SAM flag 0x800).
+    pub fn with_exclude_supplementary(mut self, v: bool) -> Self {
+        self.exclude_supplementary = v;
+        self
+    }
+
+    /// Set the strand to keep.
+    pub fn with_strand(mut self, v: bio_types::strand::Strand) -> Self {
+        self.strand = v;
+        self
+    }
+
+    /// Keep only properly paired reads.
+    pub fn with_proper_pair(mut self, v: bool) -> Self {
+        self.proper_pair = v;
+        self
+    }
+
+    /// Set the minimum mapping quality.
+    pub fn with_min_mapq(mut self, v: u8) -> Self {
+        self.min_mapq = v;
+        self
+    }
+
+    /// Set the minimum read length.
+    pub fn with_min_length(mut self, v: u32) -> Self {
+        self.min_length = v;
+        self
+    }
+
+    /// Set the maximum read length.
+    pub fn with_max_length(mut self, v: u32) -> Self {
+        self.max_length = v;
+        self
+    }
+
+    /// Set the read group to keep.
+    pub fn with_read_group(mut self, v: Option<String>) -> Self {
+        self.read_group = v;
+        self
+    }
+
+    /// Set the blacklisted locations (chromosome ID -> `Lapper`).
+    pub fn with_blacklisted_locations(
+        mut self,
+        v: Option<HashMap<usize, Lapper<usize, u32>>>,
+    ) -> Self {
+        self.blacklisted_locations = v;
+        self
+    }
+
+    /// Set the whitelisted cell barcodes.
+    pub fn with_whitelisted_barcodes(mut self, v: Option<HashSet<String>>) -> Self {
+        self.whitelisted_barcodes = v;
+        self
+    }
+
+    /// Set the SAM tag to filter by.
+    pub fn with_filter_tag(mut self, v: Option<String>) -> Self {
+        self.filter_tag = v;
+        self
+    }
+
+    /// Set the required value for `filter_tag`.
+    pub fn with_filter_tag_value(mut self, v: Option<String>) -> Self {
+        self.filter_tag_value = v;
+        self
+    }
+
+    /// Set the minimum fragment length (template/insert size).
+    pub fn with_min_fragment_length(mut self, v: Option<u32>) -> Self {
+        self.min_fragment_length = v;
+        self
+    }
+
+    /// Set the maximum fragment length (template/insert size).
+    pub fn with_max_fragment_length(mut self, v: Option<u32>) -> Self {
+        self.max_fragment_length = v;
+        self
     }
 
     /// Checks if a read is valid according to the filter criteria.
@@ -442,6 +583,26 @@ impl BamReadFilter {
                 return Ok(false);
             }
         };
+
+        // Filter by duplicate/secondary/supplementary flags (cheapest checks first).
+        if self.exclude_duplicates && flags.is_duplicate() {
+            self.stats
+                .n_failed_duplicate
+                .fetch_add(1, Ordering::Relaxed);
+            return Ok(false);
+        }
+        if self.exclude_secondary && flags.is_secondary() {
+            self.stats
+                .n_failed_secondary
+                .fetch_add(1, Ordering::Relaxed);
+            return Ok(false);
+        }
+        if self.exclude_supplementary && flags.is_supplementary() {
+            self.stats
+                .n_failed_supplementary
+                .fetch_add(1, Ordering::Relaxed);
+            return Ok(false);
+        }
 
         // Filter by strand.
         match flags.is_reverse_complemented() {
@@ -659,5 +820,81 @@ where
         Some(barcode.to_string())
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noodles::sam::alignment::RecordBuf;
+    use noodles::sam::alignment::record::Flags;
+
+    fn record_with_flags(flags: Flags) -> RecordBuf {
+        let mut record = RecordBuf::default();
+        *record.flags_mut() = flags;
+        record
+    }
+
+    #[test]
+    fn test_exclude_duplicates_filters_duplicate_reads() {
+        let filter = BamReadFilter::default().with_exclude_duplicates(true);
+        let record = record_with_flags(Flags::DUPLICATE);
+        let valid = filter.is_valid(&record, None).expect("is_valid errored");
+        assert!(!valid);
+        assert_eq!(filter.stats().n_failed_duplicate(), 1);
+    }
+
+    #[test]
+    fn test_exclude_secondary_filters_secondary_reads() {
+        let filter = BamReadFilter::default().with_exclude_secondary(true);
+        let record = record_with_flags(Flags::SECONDARY);
+        let valid = filter.is_valid(&record, None).expect("is_valid errored");
+        assert!(!valid);
+        assert_eq!(filter.stats().n_failed_secondary(), 1);
+    }
+
+    #[test]
+    fn test_exclude_supplementary_filters_supplementary_reads() {
+        let filter = BamReadFilter::default().with_exclude_supplementary(true);
+        let record = record_with_flags(Flags::SUPPLEMENTARY);
+        let valid = filter.is_valid(&record, None).expect("is_valid errored");
+        assert!(!valid);
+        assert_eq!(filter.stats().n_failed_supplementary(), 1);
+    }
+
+    #[test]
+    fn test_builder_methods_chain_and_apply() {
+        let filter = BamReadFilter::default()
+            .with_min_mapq(30)
+            .with_min_length(50)
+            .with_max_length(500)
+            .with_proper_pair(false)
+            .with_strand(bio_types::strand::Strand::Forward)
+            .with_read_group(Some("RG1".to_string()))
+            .with_filter_tag(Some("VP".to_string()))
+            .with_filter_tag_value(Some("BCL2".to_string()))
+            .with_min_fragment_length(Some(100))
+            .with_max_fragment_length(Some(200))
+            .with_exclude_duplicates(true);
+
+        // Duplicate exclusion is checked first, so a duplicate read is rejected
+        // regardless of the other builder settings above.
+        let record = record_with_flags(Flags::DUPLICATE);
+        let valid = filter.is_valid(&record, None).expect("is_valid errored");
+        assert!(!valid);
+        assert_eq!(filter.stats().n_failed_duplicate(), 1);
+    }
+
+    #[test]
+    fn test_exclude_flags_default_off_does_not_filter() {
+        let filter = BamReadFilter::default();
+        let record = record_with_flags(Flags::DUPLICATE | Flags::SECONDARY | Flags::SUPPLEMENTARY);
+        // The record is missing a header/alignment position, so the overall filter may
+        // still fail or error further down the chain; we only care that the new
+        // duplicate/secondary/supplementary counters stay untouched when disabled.
+        let _ = filter.is_valid(&record, None);
+        assert_eq!(filter.stats().n_failed_duplicate(), 0);
+        assert_eq!(filter.stats().n_failed_secondary(), 0);
+        assert_eq!(filter.stats().n_failed_supplementary(), 0);
     }
 }

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import numpy as np
-from bamnado import get_signal_for_chromosome
+from bamnado import get_signal_for_chromosome, compute_scale_factors
 
 @pytest.fixture
 def bam_file():
@@ -48,3 +48,49 @@ def test_get_signal_invalid_chrom(bam_file):
             False,
             True
         )
+
+
+def test_compute_scale_factors_tmm(bam_file):
+    """Test computing TMM scale factors for two (identical) samples."""
+    result = compute_scale_factors([bam_file, bam_file], method="tmm")
+
+    assert len(result.sample_names) == 2
+    assert len(result.scale_factors) == 2
+    assert len(result.norm_factors) == 2
+    assert len(result.library_sizes) == 2
+    for factor in result.scale_factors:
+        assert factor == pytest.approx(1.0)
+
+
+def test_compute_scale_factors_return_counts(bam_file):
+    """Test that return_counts=True populates a 2D bin count matrix."""
+    result = compute_scale_factors(
+        [bam_file, bam_file], method="tmm", return_counts=True
+    )
+
+    counts = result.counts()
+    assert counts is not None
+    assert counts.ndim == 2
+    assert counts.dtype == np.uint64
+    assert counts.shape[1] == 2
+    assert counts.shape[0] == len(result.bin_chroms)
+    assert counts.shape[0] == len(result.bin_starts)
+    assert counts.shape[0] == len(result.bin_ends)
+
+
+def test_compute_scale_factors_no_counts_by_default(bam_file):
+    """Test that counts() is None unless return_counts=True."""
+    result = compute_scale_factors([bam_file, bam_file], method="cpm")
+    assert result.counts() is None
+
+
+def test_compute_scale_factors_invalid_method(bam_file):
+    """Test that an invalid method string raises ValueError."""
+    with pytest.raises(ValueError):
+        compute_scale_factors([bam_file, bam_file], method="not-a-method")
+
+
+def test_compute_scale_factors_nonexistent_bam():
+    """Test that a nonexistent BAM file raises RuntimeError."""
+    with pytest.raises(RuntimeError):
+        compute_scale_factors(["does_not_exist.bam"], method="cpm")


### PR DESCRIPTION
This pull request introduces between-sample normalization functionality to BamNado, both in the CLI and Python API, along with expanded documentation and improved read filtering options. The main feature is the addition of new methods for computing scaling factors to correct for technical and compositional bias when comparing multiple ChIP-seq/CUT&Tag/CUT&RUN samples. The Python API now exposes `compute_scale_factors` and the associated `ScaleFactorResult`, and the CLI adds the `bam-normalize` command. Documentation has been updated to describe these new features and their usage.

**Between-sample normalization and scaling factor computation:**

* Added `bam-normalize` CLI command to compute between-sample scaling factors using methods such as TMM, csaw-background, CPM, median-of-ratios, and spike-in, with detailed documentation, usage examples, and caveats. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R81) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R249-R302)
* Exposed `compute_scale_factors` and `ScaleFactorResult` in the Python API, allowing users to compute normalization factors programmatically, with full parameter documentation and usage examples. [[1]](diffhunk://#diff-1cdb7142ccf6eae17a3a25877252f0cee4b5c2de6c696ffbde305c553e063efcL1-R15) [[2]](diffhunk://#diff-8f6e9454661e94aeb3fd2e2e078b10edde152827be746fd1850675e35a5b007cR56-R126) F1e490f9L431R489)

**Read filtering improvements:**

* Expanded `BamReadFilter` to support exclusion of duplicate, secondary, and supplementary alignments, with new chainable builder methods and corresponding CLI flags (`--ignore-duplicates`, `--ignore-secondary`, `--ignore-supplementary`). Documentation and API signatures have been updated accordingly. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L30-R37) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R101-R103) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R143-R153) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R145-R147) [[5]](diffhunk://#diff-8f6e9454661e94aeb3fd2e2e078b10edde152827be746fd1850675e35a5b007cR3-R46)

**Documentation and API reference updates:**

* Updated `CLAUDE.md` and `README.md` to document new files, types, CLI commands, Python API functions, and usage patterns related to normalization and filtering. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L16-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R177)

**Python bindings and type hints:**

* Updated Python bindings (`__init__.py`, `_bamnado.pyi`) to export the new API surface and provide comprehensive type hints and docstrings for all public methods and classes. [[1]](diffhunk://#diff-1cdb7142ccf6eae17a3a25877252f0cee4b5c2de6c696ffbde305c553e063efcL1-R15) [[2]](diffhunk://#diff-8f6e9454661e94aeb3fd2e2e078b10edde152827be746fd1850675e35a5b007cR3-R46) [[3]](diffhunk://#diff-8f6e9454661e94aeb3fd2e2e078b10edde152827be746fd1850675e35a5b007cR56-R126)

**Rust library documentation:**

* Updated Rust library documentation to mention the new normalization-related functions and result types.